### PR TITLE
Add empty github workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+name: ci
+on: ["push", "pull_request"]
+
+permissions:
+  contents: read
+
+jobs: {}


### PR DESCRIPTION
Empty github workflow is expected to enable workflows and we should be able to test and merge https://github.com/elastic/opentelemetry-lib/pull/11/files post that.