### PR TITLE
Add event.module attribute to all remapped metrics

### DIFF
--- a/remappers/common/const.go
+++ b/remappers/common/const.go
@@ -20,4 +20,8 @@ package common
 const (
 	// DatastreamDatasetLabel defines a dataset label for attributes.
 	DatastreamDatasetLabel = "data_stream.dataset"
+
+	// RemapperEventModule defines the value of the ECS attribute
+	// `event.module` that will be added to all the remapped metrics.
+	RemapperEventModule = "elastic/opentelemetry-lib"
 )

--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -53,7 +53,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 
 	systemIntegration := newConfig(remapOpts...).SystemIntegrationDataset
 	outAttr := func(scraper string) map[string]any {
-		m := map[string]any{"event.provider": "hostmetrics"}
+		m := map[string]any{"event.module": "elastic/opentelemetry-lib"}
 		if systemIntegration {
 			m[common.DatastreamDatasetLabel] = scraperToElasticDataset[scraper]
 		}

--- a/remappers/internal/metric.go
+++ b/remappers/internal/metric.go
@@ -68,7 +68,7 @@ func AddMetrics(
 			dp.SetStartTimestamp(metric.StartTimestamp)
 		}
 
-		dp.Attributes().PutStr("event.provider", "hostmetrics")
+		dp.Attributes().PutStr("event.module", common.RemapperEventModule)
 		if dataset != "" {
 			dp.Attributes().PutStr(common.DatastreamDatasetLabel, dataset)
 		}


### PR DESCRIPTION
Based on discussions with the team we will be adopting the [event.module](https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-module) ECS attribute instead of `event.provider` to taint our remapped metrics.