### PR TITLE
Fix issues in remappers

### DIFF
--- a/remappers/hostmetrics/cpu.go
+++ b/remappers/hostmetrics/cpu.go
@@ -121,7 +121,7 @@ func remapCPUMetrics(
 		},
 		remappers.Metric{
 			DataType:    pmetric.MetricTypeGauge,
-			Name:        "system.cpu.wait.pct",
+			Name:        "system.cpu.iowait.pct",
 			Timestamp:   timestamp,
 			DoubleValue: &iowaitPercent,
 		},
@@ -204,7 +204,7 @@ func remapCPUMetrics(
 		},
 		remappers.Metric{
 			DataType:    pmetric.MetricTypeGauge,
-			Name:        "system.cpu.wait.norm.pct",
+			Name:        "system.cpu.iowait.norm.pct",
 			Timestamp:   timestamp,
 			DoubleValue: &iowaitNorm,
 		},

--- a/remappers/hostmetrics/hostmetrics.go
+++ b/remappers/hostmetrics/hostmetrics.go
@@ -36,7 +36,7 @@ var scraperToElasticDataset = map[string]string{
 	"memory":     "system.memory",
 	"network":    "system.network",
 	"paging":     "system.memory",
-	"processes":  "system.process",
+	"processes":  "system.process.summary",
 	"process":    "system.process",
 }
 

--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -41,6 +41,7 @@ var (
 	ProcOwner string = "root"
 	ProcPath  string = "/bin/run"
 	ProcName  string = "runner"
+	Cmdline   string = "./dist/otelcol-ishleen-custom --config collector.yml"
 	Device    string = "en0"
 	Disk      string = "nvme0n1p128"
 )
@@ -66,6 +67,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			m["user.name"] = ProcOwner
 			m["process.executable"] = ProcPath
 			m["process.name"] = ProcName
+			m["system.process.cmdline"] = Cmdline
 		case "network":
 			m["system.network.name"] = Device
 		case "disk":
@@ -102,7 +104,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Gauge, Name: "system.cpu.system.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.68), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.user.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.5), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.steal.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.15), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.wait.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
+				{Type: Gauge, Name: "system.cpu.iowait.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.nice.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.irq.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.softirq.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
@@ -113,7 +115,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Gauge, Name: "system.cpu.system.norm.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.17), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.user.norm.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.125), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.steal.norm.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0375), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.wait.norm.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
+				{Type: Gauge, Name: "system.cpu.iowait.norm.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.nice.norm.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.irq.norm.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.softirq.norm.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
@@ -138,7 +140,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Gauge, Name: "system.cpu.system.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.68), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.user.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.5), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.steal.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.15), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.wait.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
+				{Type: Gauge, Name: "system.cpu.iowait.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.nice.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.irq.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
 				{Type: Gauge, Name: "system.cpu.softirq.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("cpu")}},
@@ -198,6 +200,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				"process.owner":           ProcOwner,
 				"process.executable.path": ProcPath,
 				"process.executable.name": ProcName,
+				"process.command_line":    Cmdline,
 			},
 			input: []internal.TestMetric{
 				{Type: Sum, Name: "process.threads", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(7))}},
@@ -238,13 +241,16 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Sum, Name: "system.processes.count", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(3)), Attrs: map[string]any{"status": "sleeping"}}},
 				{Type: Sum, Name: "system.processes.count", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(5)), Attrs: map[string]any{"status": "stopped"}}},
 				{Type: Sum, Name: "system.processes.count", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(1)), Attrs: map[string]any{"status": "zombies"}}},
+				{Type: Sum, Name: "system.processes.count", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(2)), Attrs: map[string]any{"status": "running"}}},
+				{Type: Sum, Name: "system.processes.count", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(2)), Attrs: map[string]any{"status": "paging"}}},
 			},
 			expected: []internal.TestMetric{
 				{Type: Sum, Name: "system.process.summary.idle", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(7)), Attrs: outAttr("processes")}},
 				{Type: Sum, Name: "system.process.summary.sleeping", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(3)), Attrs: outAttr("processes")}},
 				{Type: Sum, Name: "system.process.summary.stopped", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(5)), Attrs: outAttr("processes")}},
 				{Type: Sum, Name: "system.process.summary.zombie", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(1)), Attrs: outAttr("processes")}},
-				{Type: Sum, Name: "system.process.summary.total", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(16)), Attrs: outAttr("processes")}},
+				{Type: Sum, Name: "system.process.summary.running", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(2)), Attrs: outAttr("processes")}},
+				{Type: Sum, Name: "system.process.summary.total", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(20)), Attrs: outAttr("processes")}},
 			},
 		},
 		{

--- a/remappers/hostmetrics/process.go
+++ b/remappers/hostmetrics/process.go
@@ -277,5 +277,9 @@ func addProcessResources(resource pcommon.Resource) func(pmetric.NumberDataPoint
 		if name.Str() != "" {
 			dp.Attributes().PutStr("process.name", name.Str())
 		}
+		cmdline, _ := resource.Attributes().Get("process.command_line")
+		if cmdline.Str() != "" {
+			dp.Attributes().PutStr("system.process.cmdline", cmdline.Str())
+		}
 	}
 }

--- a/remappers/hostmetrics/processes.go
+++ b/remappers/hostmetrics/processes.go
@@ -30,7 +30,7 @@ func remapProcessesMetrics(
 	dataset string,
 ) error {
 	var timestamp pcommon.Timestamp
-	var idleProcesses, sleepingProcesses, stoppedProcesses, zombieProcesses, totalProcesses int64
+	var idleProcesses, sleepingProcesses, stoppedProcesses, zombieProcesses, runningProcesses, totalProcesses int64
 
 	for i := 0; i < src.Len(); i++ {
 		metric := src.At(i)
@@ -55,6 +55,11 @@ func remapProcessesMetrics(
 						totalProcesses += value
 					case "zombies":
 						zombieProcesses = value
+						totalProcesses += value
+					case "running":
+						runningProcesses = value
+						totalProcesses += value
+					default:
 						totalProcesses += value
 					}
 				}
@@ -87,6 +92,12 @@ func remapProcessesMetrics(
 			Name:      "system.process.summary.zombie",
 			Timestamp: timestamp,
 			IntValue:  &zombieProcesses,
+		},
+		remappers.Metric{
+			DataType:  pmetric.MetricTypeSum,
+			Name:      "system.process.summary.running",
+			Timestamp: timestamp,
+			IntValue:  &runningProcesses,
 		},
 		remappers.Metric{
 			DataType:  pmetric.MetricTypeSum,


### PR DESCRIPTION
1. Push the processes scraper data to system.process.summary dataset
2. Add system.process.cmdline as attribute to processmetrics
3. Update the tests 
4. Rectify the name of iowait.pct in CPU scraper
5. Improve logic of calculating total number of processes