### PR TITLE
Add k8s.pod.cpu.node.utilization metric in kubernetes remapper

### DIFF
--- a/remappers/kubernetesmetrics/k8smetrics_test.go
+++ b/remappers/kubernetesmetrics/k8smetrics_test.go
@@ -77,12 +77,13 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			input: []internal.TestMetric{
 				{Type: Gauge, Name: "k8s.pod.cpu_limit_utilization", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.26), Attrs: map[string]any{"k8s.pod.name": POD, "k8s.namespace.name": NAMESPACE}}},
 				{Type: Gauge, Name: "k8s.pod.memory_limit_utilization", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.18), Attrs: map[string]any{"k8s.pod.name": "pod0", "k8s.pod.namespace": NAMESPACE}}},
+				{Type: Gauge, Name: "k8s.pod.cpu.node.utilization", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.12), Attrs: map[string]any{"k8s.pod.name": POD, "k8s.namespace.name": NAMESPACE}}},
 				{Type: Sum, Name: "k8s.pod.network.io", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(1024)), Attrs: map[string]any{"device": DEVICE, "direction": "receive"}}},
 				{Type: Sum, Name: "k8s.pod.network.io", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(2048)), Attrs: map[string]any{"device": DEVICE, "direction": "transmit"}}},
 			},
 			expected: []internal.TestMetric{
 				{Type: Gauge, Name: "kubernetes.pod.cpu.usage.limit.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.26), Attrs: outAttr("kubeletstatsreceiver")}},
-				{Type: Gauge, Name: "kubernetes.pod.cpu.usage.node.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("kubeletstatsreceiver")}},
+				{Type: Gauge, Name: "kubernetes.pod.cpu.usage.node.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.12), Attrs: outAttr("kubeletstatsreceiver")}},
 				{Type: Gauge, Name: "kubernetes.pod.memory.usage.node.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.0), Attrs: outAttr("kubeletstatsreceiver")}},
 				{Type: Gauge, Name: "kubernetes.pod.memory.usage.limit.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.18), Attrs: outAttr("kubeletstatsreceiver")}},
 				{Type: Sum, Name: "kubernetes.pod.network.tx.bytes", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(2048)), Attrs: outAttr("kubeletstatsreceiver")}},
@@ -115,6 +116,7 @@ func BenchmarkRemap(b *testing.B) {
 	in := map[string][]internal.TestMetric{
 		"kubeletstats": []internal.TestMetric{
 			{Type: Gauge, Name: "k8s.pod.cpu_limit_utilization", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.26), Attrs: map[string]any{"k8s.pod.name": POD, "k8s.namespace.name": NAMESPACE}}},
+			{Type: Gauge, Name: "k8s.pod.cpu.node.utilization", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.12), Attrs: map[string]any{"k8s.pod.name": POD, "k8s.namespace.name": NAMESPACE}}},
 			{Type: Gauge, Name: "k8s.pod.memory_limit_utilization", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.18), Attrs: map[string]any{"k8s.pod.name": "pod0", "k8s.pod.namespace": NAMESPACE}}},
 			{Type: Sum, Name: "k8s.pod.network.io", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(1024)), Attrs: map[string]any{"device": DEVICE, "direction": "receive"}}},
 			{Type: Sum, Name: "k8s.pod.network.io", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(2048)), Attrs: map[string]any{"device": DEVICE, "direction": "transmit"}}},

--- a/remappers/kubernetesmetrics/kubelet.go
+++ b/remappers/kubernetesmetrics/kubelet.go
@@ -38,13 +38,19 @@ func addKubeletMetrics(
 	//pod
 	for i := 0; i < src.Len(); i++ {
 		metric := src.At(i)
-		// kubernetes.pod.cpu.usage.node.pct and kubernetes.pod.memory.usage.node.pct still needs to be implemented
+		// kubernetes.pod.memory.usage.node.pct still needs to be implemented
 		if metric.Name() == "k8s.pod.cpu_limit_utilization" {
 			dp := metric.Gauge().DataPoints().At(0)
 			if timestamp == 0 {
 				timestamp = dp.Timestamp()
 			}
 			cpu_limit_utilization = dp.DoubleValue()
+		} else if metric.Name() == "k8s.pod.cpu.node.utilization" {
+			dp := metric.Gauge().DataPoints().At(0)
+			if timestamp == 0 {
+				timestamp = dp.Timestamp()
+			}
+			pod_cpu_usage_node = dp.DoubleValue()
 		} else if metric.Name() == "k8s.pod.memory_limit_utilization" {
 			dp := metric.Gauge().DataPoints().At(0)
 			if timestamp == 0 {


### PR DESCRIPTION
The metric k8s.pod.cpu.node.utilization is available in [v0.103.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.103.0/receiver/kubeletstatsreceiver/documentation.md#k8spodcpunodeutilization)

So we open this PR to add missing metrics from the remapper