### PR TITLE
Add required metrics and datapoint attributes for Process tab in Host UI

### DIFF
--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -42,6 +42,7 @@ var (
 	ProcPath         string = "/bin/run"
 	ProcName         string = "runner"
 	Cmdline          string = "./dist/otelcol-ishleen-custom --config collector.yml"
+	Processstate     string = "Not Known"
 	Device           string = "en0"
 	Disk             string = "nvme0n1p128"
 	FilesystemDevice string = "dev/nvme0n1p1"
@@ -68,9 +69,10 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 		case "process":
 			m["process.parent.pid"] = PPID
 			m["user.name"] = ProcOwner
-			//	m["process.executable"] = ProcPath
+			m["process.executable"] = ProcPath
 			m["process.name"] = ProcName
 			m["system.process.cmdline"] = Cmdline
+			m["system.process.state"] = Processstate
 		case "network":
 			m["system.network.name"] = Device
 		case "disk":
@@ -203,9 +205,9 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			name:    "process",
 			scraper: "process",
 			resourceAttrs: map[string]any{
-				"process.parent_pid": PPID,
-				"process.owner":      ProcOwner,
-				//	"process.executable.path": ProcPath,
+				"process.parent_pid":      PPID,
+				"process.owner":           ProcOwner,
+				"process.executable.path": ProcPath,
 				"process.executable.name": ProcName,
 				"process.command_line":    Cmdline,
 			},
@@ -223,6 +225,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			},
 			expected: []internal.TestMetric{
 				{Type: Sum, Name: "process.cpu.start_time", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(0)), Attrs: outAttr("process")}},
+				{Type: Sum, Name: "system.process.cpu.start_time", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(0)), Attrs: outAttr("process")}},
 				{Type: Sum, Name: "system.process.num_threads", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(7)), Attrs: outAttr("process")}},
 				{Type: Gauge, Name: "system.process.memory.rss.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.15), Attrs: outAttr("process")}},
 				{Type: Sum, Name: "system.process.memory.rss.bytes", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(2048)), Attrs: outAttr("process")}},

--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -42,7 +42,7 @@ var (
 	ProcPath         string = "/bin/run"
 	ProcName         string = "runner"
 	Cmdline          string = "./dist/otelcol-ishleen-custom --config collector.yml"
-	Processstate     string = "Not Known"
+	Processstate     string = "undefined"
 	Device           string = "en0"
 	Disk             string = "nvme0n1p128"
 	FilesystemDevice string = "dev/nvme0n1p1"

--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -68,7 +68,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 		case "process":
 			m["process.parent.pid"] = PPID
 			m["user.name"] = ProcOwner
-			m["process.executable"] = ProcPath
+			//	m["process.executable"] = ProcPath
 			m["process.name"] = ProcName
 			m["system.process.cmdline"] = Cmdline
 		case "network":
@@ -203,9 +203,9 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			name:    "process",
 			scraper: "process",
 			resourceAttrs: map[string]any{
-				"process.parent_pid":      PPID,
-				"process.owner":           ProcOwner,
-				"process.executable.path": ProcPath,
+				"process.parent_pid": PPID,
+				"process.owner":      ProcOwner,
+				//	"process.executable.path": ProcPath,
 				"process.executable.name": ProcName,
 				"process.command_line":    Cmdline,
 			},

--- a/remappers/hostmetrics/process.go
+++ b/remappers/hostmetrics/process.go
@@ -290,7 +290,7 @@ func addProcessResources(resource pcommon.Resource) func(pmetric.NumberDataPoint
 			dp.Attributes().PutStr("system.process.cmdline", cmdline.Str())
 		}
 		//Adding dummy value to process.state as "Not Known", since this field is not
-		//available through Hostmetrics currently and Process tab in Curated UI's needs this field as a prerequisite to work
+		//available through Hostmetrics receiver currently and Process tab in Curated UI's need this field as a prerequisite.
 		dp.Attributes().PutStr("system.process.state", "Not Known")
 	}
 }

--- a/remappers/hostmetrics/process.go
+++ b/remappers/hostmetrics/process.go
@@ -289,8 +289,8 @@ func addProcessResources(resource pcommon.Resource) func(pmetric.NumberDataPoint
 		if cmdline.Str() != "" {
 			dp.Attributes().PutStr("system.process.cmdline", cmdline.Str())
 		}
-		//Adding dummy value to process.state as "Not Known", since this field is not
+		//Adding dummy value to process.state as "undefined", since this field is not
 		//available through Hostmetrics receiver currently and Process tab in Curated UI's need this field as a prerequisite.
-		dp.Attributes().PutStr("system.process.state", "Not Known")
+		dp.Attributes().PutStr("system.process.state", "undefined")
 	}
 }

--- a/remappers/hostmetrics/process.go
+++ b/remappers/hostmetrics/process.go
@@ -269,10 +269,10 @@ func addProcessResources(resource pcommon.Resource) func(pmetric.NumberDataPoint
 		if owner.Str() != "" {
 			dp.Attributes().PutStr("user.name", owner.Str())
 		}
-		exec, _ := resource.Attributes().Get("process.executable.path")
-		if exec.Str() != "" {
-			dp.Attributes().PutStr("process.executable", exec.Str())
-		}
+		/*		exec, _ := resource.Attributes().Get("process.executable.path")
+				if exec.Str() != "" {
+					dp.Attributes().PutStr("process.executable", exec.Str())
+				}*/
 		name, _ := resource.Attributes().Get("process.executable.name")
 		if name.Str() != "" {
 			dp.Attributes().PutStr("process.name", name.Str())

--- a/remappers/hostmetrics/process.go
+++ b/remappers/hostmetrics/process.go
@@ -157,8 +157,8 @@ func remapProcessMetrics(
 	cpuPct = cpuTimeValue / float64(processRuntime)
 
 	remappers.AddMetrics(out, dataset, addProcessResources(resource),
-		// The timestamp metrics gets converted from Int to Timestamp
-		// since the mapping for these fields in timestamp in the UI
+		// The timestamp metrics get converted from Int to Timestamp in Kibana
+		// since these are mapped to timestamp datatype
 		remappers.Metric{
 			DataType:  pmetric.MetricTypeSum,
 			Name:      "process.cpu.start_time",


### PR DESCRIPTION
Relates: https://github.com/elastic/opentelemetry-dev/issues/296

Post the fix, the Process tab lights up

<img width="1455" alt="Screenshot 2024-07-02 at 6 30 08 PM" src="https://github.com/elastic/opentelemetry-lib/assets/102962586/ec49f61f-180b-4e77-bc40-d61ace7291f7">
