### PR TITLE
Send system.process.cpu.start_time as a field

### DIFF
--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -73,6 +73,9 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			m["process.name"] = ProcName
 			m["system.process.cmdline"] = Cmdline
 			m["system.process.state"] = Processstate
+			m["system.process.cpu.start_time"] = time.Unix(0, 0).UTC().Format(time.RFC3339)
+		case "processes":
+			m["event.dataset"] = "system.process.summary"
 		case "network":
 			m["system.network.name"] = Device
 		case "disk":
@@ -225,7 +228,6 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			},
 			expected: []internal.TestMetric{
 				{Type: Sum, Name: "process.cpu.start_time", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(0)), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.cpu.start_time", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(0)), Attrs: outAttr("process")}},
 				{Type: Sum, Name: "system.process.num_threads", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(7)), Attrs: outAttr("process")}},
 				{Type: Gauge, Name: "system.process.memory.rss.pct", DP: internal.TestDP{Ts: now, Dbl: internal.Ptr(0.15), Attrs: outAttr("process")}},
 				{Type: Sum, Name: "system.process.memory.rss.bytes", DP: internal.TestDP{Ts: now, Int: internal.Ptr(int64(2048)), Attrs: outAttr("process")}},

--- a/remappers/hostmetrics/processes.go
+++ b/remappers/hostmetrics/processes.go
@@ -68,7 +68,15 @@ func remapProcessesMetrics(
 
 	}
 
-	remappers.AddMetrics(out, dataset, remappers.EmptyMutator,
+	remappers.AddMetrics(out, dataset,
+		func(dp pmetric.NumberDataPoint) {
+			// Processes tab in the Kibana curated UI requires the event.dataset
+			// to work. This is a hard dependency.
+			// TODO (lahsivjar): Unlike datastrea.dataset, we may want to set the
+			// event.dataset for all cases, would require refactoring the private
+			// remap functions.
+			dp.Attributes().PutStr("event.dataset", "system.process.summary")
+		},
 		remappers.Metric{
 			DataType:  pmetric.MetricTypeSum,
 			Name:      "system.process.summary.idle",


### PR DESCRIPTION
* Converts the `system.process.cpu.start_time` to a field with string date. The string date format allows the field to be correctly detected as a `date` field rather than an `int` field by the dynamic mapping used by APM. The date mapping is required by Kibana to parse the field correctly in the Process tab.
* Adds `event.dataset` for the process summary metric which is again required by the Process tab.