### PR TITLE
Fix k8s benchmark

### DIFF
--- a/remappers/kubernetesmetrics/k8smetrics_test.go
+++ b/remappers/kubernetesmetrics/k8smetrics_test.go
@@ -114,7 +114,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 func BenchmarkRemap(b *testing.B) {
 	now := pcommon.NewTimestampFromTime(time.Now())
 	in := map[string][]testutils.TestMetric{
-		"kubeletstats": []testutils.TestMetric{
+		"kubeletstatsreceiver": []testutils.TestMetric{
 			{Type: Gauge, Name: "k8s.pod.cpu_limit_utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.26), Attrs: map[string]any{"k8s.pod.name": POD, "k8s.namespace.name": NAMESPACE}}},
 			{Type: Gauge, Name: "k8s.pod.cpu.node.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.12), Attrs: map[string]any{"k8s.pod.name": POD, "k8s.namespace.name": NAMESPACE}}},
 			{Type: Gauge, Name: "k8s.pod.memory_limit_utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.18), Attrs: map[string]any{"k8s.pod.name": "pod0", "k8s.pod.namespace": NAMESPACE}}},


### PR DESCRIPTION
The benchmark was not doing anything since the scraper was incorrectly configured.

Bench results before the PR:

```
$ go test -run=^$ -bench=. ./...                                                     [9:03:18]
goos: darwin
goarch: arm64
pkg: github.com/elastic/opentelemetry-lib/remappers/kubernetesmetrics
BenchmarkRemap-10    	26727282	        44.76 ns/op	      28 B/op	       2 allocs/op
PASS
```

Bench results after the PR:

```
$ go test -run=^$ -bench=. ./...                                                                                                                                                     [9:04:04]
goos: darwin
goarch: arm64
pkg: github.com/elastic/opentelemetry-lib/remappers/kubernetesmetrics
BenchmarkRemap-10    	  446833	      2658 ns/op	    3800 B/op	     113 allocs/op
PASS
ok  	github.com/elastic/opentelemetry-lib/remappers/kubernetesmetrics	2.464s
```