### PR TITLE
Add event.dataset to all remapped metrics

### DIFF
--- a/remappers/common/const.go
+++ b/remappers/common/const.go
@@ -18,6 +18,12 @@
 package common
 
 const (
-	// DatastreamDatasetLabel defines a dataset label for attributes.
+	// DatastreamDatasetLabel defines the datastream dataset label key.
 	DatastreamDatasetLabel = "data_stream.dataset"
+
+	// EventDatasetLabel defines the event dataset label key.
+	EventDatasetLabel = "event.dataset"
+
+	// OTelRemappedLabel is used to identify remapped metrics.
+	OTelRemappedLabel = "otel_remapped"
 )

--- a/remappers/hostmetrics/cpu.go
+++ b/remappers/hostmetrics/cpu.go
@@ -29,7 +29,7 @@ import (
 func remapCPUMetrics(
 	src, out pmetric.MetricSlice,
 	_ pcommon.Resource,
-	dataset string,
+	mutator func(pmetric.NumberDataPoint),
 ) error {
 	var timestamp pcommon.Timestamp
 	var numCores int64
@@ -88,7 +88,7 @@ func remapCPUMetrics(
 	}
 
 	// Add all metrics that are independent of cpu logical count.
-	remappedmetric.Add(out, dataset, remappedmetric.EmptyMutator,
+	remappedmetric.Add(out, mutator,
 		remappedmetric.Metric{
 			DataType:    pmetric.MetricTypeGauge,
 			Name:        "system.cpu.total.pct",
@@ -159,7 +159,7 @@ func remapCPUMetrics(
 	irqNorm := irqPercent / float64(numCores)
 	softirqNorm := softirqPercent / float64(numCores)
 
-	remappedmetric.Add(out, dataset, remappedmetric.EmptyMutator,
+	remappedmetric.Add(out, mutator,
 		remappedmetric.Metric{
 			DataType:  pmetric.MetricTypeSum,
 			Name:      "system.cpu.cores",

--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -60,9 +60,13 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 
 	systemIntegration := newConfig(remapOpts...).SystemIntegrationDataset
 	outAttr := func(scraper string) map[string]any {
-		m := map[string]any{"otel_remapped": true}
+		dataset := scraperToElasticDataset[scraper]
+		m := map[string]any{
+			common.OTelRemappedLabel: true,
+			common.EventDatasetLabel: dataset,
+		}
 		if systemIntegration {
-			m[common.DatastreamDatasetLabel] = scraperToElasticDataset[scraper]
+			m[common.DatastreamDatasetLabel] = dataset
 		}
 
 		switch scraper {

--- a/remappers/hostmetrics/load.go
+++ b/remappers/hostmetrics/load.go
@@ -29,7 +29,7 @@ import (
 func remapLoadMetrics(
 	src, out pmetric.MetricSlice,
 	_ pcommon.Resource,
-	dataset string,
+	mutator func(pmetric.NumberDataPoint),
 ) error {
 	var timestamp pcommon.Timestamp
 	var l1, l5, l15 float64
@@ -57,7 +57,7 @@ func remapLoadMetrics(
 		}
 	}
 
-	remappedmetric.Add(out, dataset, remappedmetric.EmptyMutator,
+	remappedmetric.Add(out, mutator,
 		remappedmetric.Metric{
 			DataType:    pmetric.MetricTypeGauge,
 			Name:        "system.load.1",

--- a/remappers/hostmetrics/memory.go
+++ b/remappers/hostmetrics/memory.go
@@ -26,7 +26,7 @@ import (
 func remapMemoryMetrics(
 	src, out pmetric.MetricSlice,
 	_ pcommon.Resource,
-	dataset string,
+	mutator func(pmetric.NumberDataPoint),
 ) error {
 	var timestamp pcommon.Timestamp
 	var total, free, cached, usedBytes, actualFree, actualUsedBytes int64
@@ -96,7 +96,7 @@ func remapMemoryMetrics(
 	usedBytes += total
 	actualFree = total - actualUsedBytes
 
-	remappedmetric.Add(out, dataset, remappedmetric.EmptyMutator,
+	remappedmetric.Add(out, mutator,
 		remappedmetric.Metric{
 			DataType:  pmetric.MetricTypeSum,
 			Name:      "system.memory.total",

--- a/remappers/internal/remappedmetric/mutator.go
+++ b/remappers/internal/remappedmetric/mutator.go
@@ -15,27 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package hostmetrics
+package remappedmetric
 
-type config struct {
-	SystemIntegrationDataset bool
-}
+import (
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
 
-// Option allows configuring the behavior of the hostmetrics remapper.
-type Option func(config) config
+// EmptyMutator is a no-op mutator.
+var EmptyMutator = func(pmetric.NumberDataPoint) {}
 
-func newConfig(opts ...Option) (cfg config) {
-	for _, opt := range opts {
-		cfg = opt(cfg)
-	}
-	return cfg
-}
-
-// WithSystemIntegrationDataset sets the datastream dataset of the remapped
-// metrics as as per the system integration. Example: system.cpu, system.memory, etc.
-func WithSystemIntegrationDataset(b bool) Option {
-	return func(c config) config {
-		c.SystemIntegrationDataset = b
-		return c
+// ChainedMutator combines multiple mutators into a single mutator.
+func ChainedMutator(fs ...func(pmetric.NumberDataPoint)) func(pmetric.NumberDataPoint) {
+	return func(m pmetric.NumberDataPoint) {
+		for _, f := range fs {
+			f(m)
+		}
 	}
 }

--- a/remappers/kubernetesmetrics/clustermetrics.go
+++ b/remappers/kubernetesmetrics/clustermetrics.go
@@ -27,7 +27,7 @@ import (
 func addClusterMetrics(
 	src, out pmetric.MetricSlice,
 	_ pcommon.Resource,
-	dataset string,
+	mutator func(pmetric.NumberDataPoint),
 ) error {
 	var timestamp pcommon.Timestamp
 	var node_allocatable_memory, node_allocatable_cpu int64
@@ -50,7 +50,7 @@ func addClusterMetrics(
 		}
 	}
 
-	remappedmetric.Add(out, dataset, remappedmetric.EmptyMutator,
+	remappedmetric.Add(out, mutator,
 		remappedmetric.Metric{
 			DataType:  pmetric.MetricTypeGauge,
 			Name:      "kubernetes.node.cpu.allocatable.cores",

--- a/remappers/kubernetesmetrics/k8smetrics_test.go
+++ b/remappers/kubernetesmetrics/k8smetrics_test.go
@@ -50,10 +50,14 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 
 	kubernetesIntegration := newConfig(remapOpts...).KubernetesIntegrationDataset
 	outAttr := func(scraper string) map[string]any {
-		m := map[string]any{"otel_remapped": true}
-		m["service.type"] = "kubernetes"
+		dataset := scraperToElasticDataset[scraper]
+		m := map[string]any{
+			common.OTelRemappedLabel: true,
+			common.EventDatasetLabel: dataset,
+			"service.type":           "kubernetes",
+		}
 		if kubernetesIntegration {
-			m[common.DatastreamDatasetLabel] = scraperToElasticDataset[scraper]
+			m[common.DatastreamDatasetLabel] = dataset
 		}
 		return m
 	}


### PR DESCRIPTION
Unlike `data_stream.dataset` which doesn't need to be set for the APM path, the `event.dataset` is required for multiple UI panels. The PR allows setting the dataset in all cases and adopts the mutator pattern throughout the codebase.

There are no major logic changes other than all metrics having `event.dataset` set as a datapoint attribute.