### PR TITLE
Handle user.name/system_cmdline if not present

### DIFF
--- a/remappers/hostmetrics/process.go
+++ b/remappers/hostmetrics/process.go
@@ -279,6 +279,8 @@ func addProcessResources(resource pcommon.Resource, startTime time.Time) func(pm
 		owner, _ := resource.Attributes().Get("process.owner")
 		if owner.Str() != "" {
 			dp.Attributes().PutStr("user.name", owner.Str())
+		} else {
+			dp.Attributes().PutStr("user.name", "undefined")
 		}
 		exec, _ := resource.Attributes().Get("process.executable.path")
 		if exec.Str() != "" {
@@ -291,6 +293,8 @@ func addProcessResources(resource pcommon.Resource, startTime time.Time) func(pm
 		cmdline, _ := resource.Attributes().Get("process.command_line")
 		if cmdline.Str() != "" {
 			dp.Attributes().PutStr("system.process.cmdline", cmdline.Str())
+		} else {
+			dp.Attributes().PutStr("system.process.cmdline", "undefined")
 		}
 		dp.Attributes().PutStr("system.process.cpu.start_time", startTimeStr)
 		// Adding dummy value to process.state as "undefined", since this field is not


### PR DESCRIPTION
In some scenarios, we have observed that the user.name is not fetched since ots corresponding OTEL metric(process.owner) is not present. 
But the absence of user.name leads to the process tab not working in Curated UI's. Hecne adding default value of "undefined" in case not present.
The same is done for system_cmdline for the same reasons