### PR TITLE
Set event.module for hostmetrics remapper

### DIFF
--- a/remappers/common/const.go
+++ b/remappers/common/const.go
@@ -24,6 +24,9 @@ const (
 	// EventDatasetLabel defines the event dataset label key.
 	EventDatasetLabel = "event.dataset"
 
+	// EventModuleLabel defines the event module label key.
+	EventModuleLabel = "event.module"
+
 	// OTelRemappedLabel is used to identify remapped metrics.
 	OTelRemappedLabel = "otel_remapped"
 )

--- a/remappers/hostmetrics/hostmetrics.go
+++ b/remappers/hostmetrics/hostmetrics.go
@@ -95,6 +95,7 @@ func (r *Remapper) Remap(
 	}
 	datasetMutator := func(m pmetric.NumberDataPoint) {
 		m.Attributes().PutStr(common.EventDatasetLabel, dataset)
+		m.Attributes().PutStr(common.EventModuleLabel, "system")
 		if r.cfg.SystemIntegrationDataset {
 			m.Attributes().PutStr(common.DatastreamDatasetLabel, dataset)
 		}

--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -64,6 +64,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 		m := map[string]any{
 			common.OTelRemappedLabel: true,
 			common.EventDatasetLabel: dataset,
+			common.EventModuleLabel:  "system",
 		}
 		if systemIntegration {
 			m[common.DatastreamDatasetLabel] = dataset


### PR DESCRIPTION
`event.module` is required to make the Observability Overview panel work for the APM path.