### PR TITLE
refactor: drop toolchain dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opentelemetry-lib
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Do not introduce toolchain dependencies and let client decide what to do with the go directive