### PR TITLE
[enrichments] Add agent.version

### DIFF
--- a/enrichments/trace/config/config.go
+++ b/enrichments/trace/config/config.go
@@ -26,7 +26,8 @@ type Config struct {
 
 // ResourceConfig configures the enrichment of resource attributes.
 type ResourceConfig struct {
-	AgentName AttributeConfig `mapstructure:"agent_name"`
+	AgentName    AttributeConfig `mapstructure:"agent_name"`
+	AgentVersion AttributeConfig `mapstructure:"agent_version"`
 }
 
 // ElasticTransactionConfig configures the enrichment attributes for the
@@ -56,7 +57,8 @@ type AttributeConfig struct {
 func Enabled() Config {
 	return Config{
 		Resource: ResourceConfig{
-			AgentName: AttributeConfig{Enabled: true},
+			AgentName:    AttributeConfig{Enabled: true},
+			AgentVersion: AttributeConfig{Enabled: true},
 		},
 		Transaction: ElasticTransactionConfig{
 			Root:         AttributeConfig{Enabled: true},

--- a/enrichments/trace/internal/elastic/attributes.go
+++ b/enrichments/trace/internal/elastic/attributes.go
@@ -19,7 +19,8 @@ package elastic
 
 const (
 	// resource attributes
-	AttributeAgentName = "agent.name"
+	AttributeAgentName    = "agent.name"
+	AttributeAgentVersion = "agent.version"
 
 	// span attributes
 	AttributeTransactionRoot   = "transaction.root"

--- a/enrichments/trace/internal/elastic/resource.go
+++ b/enrichments/trace/internal/elastic/resource.go
@@ -94,10 +94,12 @@ func (s *resourceEnrichmentContext) setAgentName(resource pcommon.Resource) {
 func (s *resourceEnrichmentContext) setAgentVersion(resource pcommon.Resource) {
 	agentVersion := "unknown"
 	switch {
-	case s.telemetryDistroName != "" && s.telemetryDistroVersion != "":
-		// do not want to fallback to the Otel SDK version if we have a
+	case s.telemetryDistroName != "":
+		// do not fallback to the Otel SDK version if we have a
 		// distro name available as this would only cause confusion
-		agentVersion = s.telemetryDistroVersion
+		if s.telemetryDistroVersion != "" {
+			agentVersion = s.telemetryDistroVersion
+		}
 	case s.telemetrySDKVersion != "":
 		agentVersion = s.telemetrySDKVersion
 	}

--- a/enrichments/trace/internal/elastic/resource_test.go
+++ b/enrichments/trace/internal/elastic/resource_test.go
@@ -143,7 +143,7 @@ func TestResourceEnrich(t *testing.T) {
 			config: config.Enabled().Resource,
 			enrichedAttrs: map[string]any{
 				AttributeAgentName:    "customflavor/unknown/elastic",
-				AttributeAgentVersion: "9.999.9",
+				AttributeAgentVersion: "unknown",
 			},
 		},
 		{

--- a/enrichments/trace/internal/elastic/resource_test.go
+++ b/enrichments/trace/internal/elastic/resource_test.go
@@ -44,11 +44,12 @@ func TestResourceEnrich(t *testing.T) {
 			input:  pcommon.NewResource(),
 			config: config.Enabled().Resource,
 			enrichedAttrs: map[string]any{
-				AttributeAgentName: "otlp",
+				AttributeAgentName:    "otlp",
+				AttributeAgentVersion: "unknown",
 			},
 		},
 		{
-			name: "sdk_name_set",
+			name: "sdkname_set",
 			input: func() pcommon.Resource {
 				res := pcommon.NewResource()
 				res.Attributes().PutStr(semconv.AttributeTelemetrySDKName, "customflavor")
@@ -56,11 +57,12 @@ func TestResourceEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled().Resource,
 			enrichedAttrs: map[string]any{
-				AttributeAgentName: "customflavor",
+				AttributeAgentName:    "customflavor",
+				AttributeAgentVersion: "unknown",
 			},
 		},
 		{
-			name: "sdk_name_distro_set",
+			name: "sdkname_distro_set",
 			input: func() pcommon.Resource {
 				res := pcommon.NewResource()
 				res.Attributes().PutStr(semconv.AttributeTelemetrySDKName, "customflavor")
@@ -69,11 +71,12 @@ func TestResourceEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled().Resource,
 			enrichedAttrs: map[string]any{
-				AttributeAgentName: "customflavor/unknown/elastic",
+				AttributeAgentName:    "customflavor/unknown/elastic",
+				AttributeAgentVersion: "unknown",
 			},
 		},
 		{
-			name: "sdk_name_distro_lang_set",
+			name: "sdkname_distro_lang_set",
 			input: func() pcommon.Resource {
 				res := pcommon.NewResource()
 				res.Attributes().PutStr(semconv.AttributeTelemetrySDKName, "customflavor")
@@ -83,7 +86,8 @@ func TestResourceEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled().Resource,
 			enrichedAttrs: map[string]any{
-				AttributeAgentName: "customflavor/cpp/elastic",
+				AttributeAgentName:    "customflavor/cpp/elastic",
+				AttributeAgentVersion: "unknown",
 			},
 		},
 		{
@@ -95,11 +99,12 @@ func TestResourceEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled().Resource,
 			enrichedAttrs: map[string]any{
-				AttributeAgentName: "otlp/cpp",
+				AttributeAgentName:    "otlp/cpp",
+				AttributeAgentVersion: "unknown",
 			},
 		},
 		{
-			name: "sdk_name_lang_set",
+			name: "sdkname_lang_set",
 			input: func() pcommon.Resource {
 				res := pcommon.NewResource()
 				res.Attributes().PutStr(semconv.AttributeTelemetrySDKName, "customflavor")
@@ -108,7 +113,53 @@ func TestResourceEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled().Resource,
 			enrichedAttrs: map[string]any{
-				AttributeAgentName: "customflavor/cpp",
+				AttributeAgentName:    "customflavor/cpp",
+				AttributeAgentVersion: "unknown",
+			},
+		},
+		{
+			name: "sdkname_sdkver_set",
+			input: func() pcommon.Resource {
+				res := pcommon.NewResource()
+				res.Attributes().PutStr(semconv.AttributeTelemetrySDKName, "customflavor")
+				res.Attributes().PutStr(semconv.AttributeTelemetrySDKVersion, "9.999.9")
+				return res
+			}(),
+			config: config.Enabled().Resource,
+			enrichedAttrs: map[string]any{
+				AttributeAgentName:    "customflavor",
+				AttributeAgentVersion: "9.999.9",
+			},
+		},
+		{
+			name: "sdkname_sdkver_distroname_set",
+			input: func() pcommon.Resource {
+				res := pcommon.NewResource()
+				res.Attributes().PutStr(semconv.AttributeTelemetrySDKName, "customflavor")
+				res.Attributes().PutStr(semconv.AttributeTelemetrySDKVersion, "9.999.9")
+				res.Attributes().PutStr(semconv.AttributeTelemetryDistroName, "elastic")
+				return res
+			}(),
+			config: config.Enabled().Resource,
+			enrichedAttrs: map[string]any{
+				AttributeAgentName:    "customflavor/unknown/elastic",
+				AttributeAgentVersion: "9.999.9",
+			},
+		},
+		{
+			name: "sdkname_sdkver_distroname_distrover_set",
+			input: func() pcommon.Resource {
+				res := pcommon.NewResource()
+				res.Attributes().PutStr(semconv.AttributeTelemetrySDKName, "customflavor")
+				res.Attributes().PutStr(semconv.AttributeTelemetrySDKVersion, "9.999.9")
+				res.Attributes().PutStr(semconv.AttributeTelemetryDistroName, "elastic")
+				res.Attributes().PutStr(semconv.AttributeTelemetryDistroVersion, "1.2.3")
+				return res
+			}(),
+			config: config.Enabled().Resource,
+			enrichedAttrs: map[string]any{
+				AttributeAgentName:    "customflavor/unknown/elastic",
+				AttributeAgentVersion: "1.2.3",
 			},
 		},
 	} {


### PR DESCRIPTION
Adds enrichment for `agent.version` as per [apm-data](https://github.com/elastic/apm-data/blob/main/input/otlp/metadata.go)