### PR TITLE
Remove txn.root and add trace.root as enrichment

### DIFF
--- a/enrichments/trace/config/config.go
+++ b/enrichments/trace/config/config.go
@@ -33,7 +33,7 @@ type ResourceConfig struct {
 // ElasticTransactionConfig configures the enrichment attributes for the
 // spans which are identified as elastic transaction.
 type ElasticTransactionConfig struct {
-	Root         AttributeConfig `mapstructure:"root"`
+	TraceRoot    AttributeConfig `mapstructure:"trace_root"`
 	Name         AttributeConfig `mapstructure:"name"`
 	Type         AttributeConfig `mapstructure:"type"`
 	Result       AttributeConfig `mapstructure:"result"`
@@ -61,7 +61,7 @@ func Enabled() Config {
 			AgentVersion: AttributeConfig{Enabled: true},
 		},
 		Transaction: ElasticTransactionConfig{
-			Root:         AttributeConfig{Enabled: true},
+			TraceRoot:    AttributeConfig{Enabled: true},
 			Name:         AttributeConfig{Enabled: true},
 			Type:         AttributeConfig{Enabled: true},
 			Result:       AttributeConfig{Enabled: true},


### PR DESCRIPTION
Initially, the plan was to deduce `trace.root` using OTTL support but that would not be available with the connector in the near future. So, creating a new key `trace.root`.

Also, removing the key `transaction.root` which was used to identify a transaction previously. We don't need this anymore in the latest version of how the pipeline works.