### PR TITLE
fix: udate hostmetrics scrapers names

### DIFF
--- a/remappers/hostmetrics/hostmetrics.go
+++ b/remappers/hostmetrics/hostmetrics.go
@@ -27,31 +27,31 @@ import (
 	"go.uber.org/zap"
 )
 
-const scopePrefix = "otelcol/hostmetricsreceiver"
+const scopePrefix = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
 
 var scraperToElasticDataset = map[string]string{
-	"cpu":        "system.cpu",
-	"disk":       "system.diskio",
-	"filesystem": "system.filesystem",
-	"load":       "system.load",
-	"memory":     "system.memory",
-	"network":    "system.network",
-	"paging":     "system.memory",
-	"processes":  "system.process.summary",
-	"process":    "system.process",
+	"cpuscraper":        "system.cpu",
+	"diskscraper":       "system.diskio",
+	"filesystemscraper": "system.filesystem",
+	"loadscraper":       "system.load",
+	"memoryscraper":     "system.memory",
+	"networkscraper":    "system.network",
+	"pagingscraper":     "system.memory",
+	"processesscraper":  "system.process.summary",
+	"processscraper":    "system.process",
 }
 
 type remapFunc func(pmetric.MetricSlice, pmetric.MetricSlice, pcommon.Resource, func(pmetric.NumberDataPoint)) error
 
 var remapFuncs = map[string]remapFunc{
-	"cpu":        remapCPUMetrics,
-	"memory":     remapMemoryMetrics,
-	"load":       remapLoadMetrics,
-	"process":    remapProcessMetrics,
-	"processes":  remapProcessesMetrics,
-	"network":    remapNetworkMetrics,
-	"disk":       remapDiskMetrics,
-	"filesystem": remapFilesystemMetrics,
+	"cpuscraper":        remapCPUMetrics,
+	"memoryscraper":     remapMemoryMetrics,
+	"loadscraper":       remapLoadMetrics,
+	"processscraper":    remapProcessMetrics,
+	"processesscraper":  remapProcessesMetrics,
+	"networkscraper":    remapNetworkMetrics,
+	"diskscraper":       remapDiskMetrics,
+	"filesystemscraper": remapFilesystemMetrics,
 }
 
 // Remapper maps the OTel hostmetrics to Elastic system metrics. These remapped

--- a/remappers/hostmetrics/hostmetrics_test.go
+++ b/remappers/hostmetrics/hostmetrics_test.go
@@ -71,7 +71,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 		}
 
 		switch scraper {
-		case "process":
+		case "processscraper":
 			m["process.parent.pid"] = PPID
 			m["user.name"] = ProcOwner
 			m["process.executable"] = ProcPath
@@ -79,13 +79,13 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			m["system.process.cmdline"] = Cmdline
 			m["system.process.state"] = Processstate
 			m["system.process.cpu.start_time"] = time.Unix(0, 0).UTC().Format(time.RFC3339)
-		case "processes":
+		case "processesscraper":
 			m["event.dataset"] = "system.process.summary"
-		case "network":
+		case "networkscraper":
 			m["system.network.name"] = Device
-		case "disk":
+		case "diskscraper":
 			m["system.diskio.name"] = Disk
-		case "filesystem":
+		case "filesystemscraper":
 			m["system.filesystem.device_name"] = FilesystemDevice
 			m["system.filesystem.mount_point"] = mpoint
 			m["system.filesystem.type"] = fstype
@@ -103,7 +103,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 	}{
 		{
 			name:    "cpu",
-			scraper: "cpu",
+			scraper: "cpuscraper",
 			input: []testutils.TestMetric{
 				{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.26), Attrs: map[string]any{"cpu": "cpu0", "state": "user"}}},
 				{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.24), Attrs: map[string]any{"cpu": "cpu0", "state": "system"}}},
@@ -116,31 +116,31 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Sum, Name: "system.cpu.logical.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4))}},
 			},
 			expected: []testutils.TestMetric{
-				{Type: Gauge, Name: "system.cpu.total.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(1.33), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.idle.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.82), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.system.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.68), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.user.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.5), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.steal.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.15), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.iowait.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.nice.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.irq.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.softirq.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Sum, Name: "system.cpu.cores", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4)), Attrs: outAttr("cpu")}},
-				{Type: Sum, Name: "system.load.cores", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4)), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.total.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.3325), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.idle.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.205), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.system.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.17), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.user.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.125), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.steal.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0375), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.iowait.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.nice.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.irq.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.softirq.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
+				{Type: Gauge, Name: "system.cpu.total.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(1.33), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.idle.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.82), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.system.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.68), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.user.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.5), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.steal.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.15), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.iowait.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.nice.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.irq.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.softirq.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Sum, Name: "system.cpu.cores", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4)), Attrs: outAttr("cpuscraper")}},
+				{Type: Sum, Name: "system.load.cores", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4)), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.total.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.3325), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.idle.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.205), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.system.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.17), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.user.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.125), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.steal.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0375), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.iowait.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.nice.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.irq.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.softirq.norm.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
 			},
 		},
 		{
 			name:    "cpu_without_logical_count",
-			scraper: "cpu",
+			scraper: "cpuscraper",
 			input: []testutils.TestMetric{
 				{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.26), Attrs: map[string]any{"cpu": "cpu0", "state": "user"}}},
 				{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.24), Attrs: map[string]any{"cpu": "cpu0", "state": "system"}}},
@@ -152,34 +152,34 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.05), Attrs: map[string]any{"cpu": "cpu1", "state": "steal"}}},
 			},
 			expected: []testutils.TestMetric{
-				{Type: Gauge, Name: "system.cpu.total.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(1.33), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.idle.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.82), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.system.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.68), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.user.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.5), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.steal.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.15), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.iowait.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.nice.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.irq.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
-				{Type: Gauge, Name: "system.cpu.softirq.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpu")}},
+				{Type: Gauge, Name: "system.cpu.total.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(1.33), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.idle.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.82), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.system.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.68), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.user.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.5), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.steal.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.15), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.iowait.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.nice.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.irq.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
+				{Type: Gauge, Name: "system.cpu.softirq.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("cpuscraper")}},
 			},
 		},
 		{
 			name:    "load",
-			scraper: "load",
+			scraper: "loadscraper",
 			input: []testutils.TestMetric{
 				{Type: Gauge, Name: "system.cpu.load_average.1m", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.14)}},
 				{Type: Gauge, Name: "system.cpu.load_average.5m", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.12)}},
 				{Type: Gauge, Name: "system.cpu.load_average.15m", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.05)}},
 			},
 			expected: []testutils.TestMetric{
-				{Type: Gauge, Name: "system.load.1", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.14), Attrs: outAttr("load")}},
-				{Type: Gauge, Name: "system.load.5", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.12), Attrs: outAttr("load")}},
-				{Type: Gauge, Name: "system.load.15", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.05), Attrs: outAttr("load")}},
+				{Type: Gauge, Name: "system.load.1", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.14), Attrs: outAttr("loadscraper")}},
+				{Type: Gauge, Name: "system.load.5", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.12), Attrs: outAttr("loadscraper")}},
+				{Type: Gauge, Name: "system.load.15", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.05), Attrs: outAttr("loadscraper")}},
 			},
 		},
 		{
 			name:    "memory",
-			scraper: "memory",
+			scraper: "memoryscraper",
 			input: []testutils.TestMetric{
 				{Type: Sum, Name: "system.memory.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024)), Attrs: map[string]any{"state": "buffered"}}},
 				{Type: Sum, Name: "system.memory.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(512)), Attrs: map[string]any{"state": "cached"}}},
@@ -198,20 +198,20 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 			},
 			expected: []testutils.TestMetric{
 				// total = used + free + buffered + cached as gopsutil calculates used = total - free - buffered - cached
-				{Type: Sum, Name: "system.memory.total", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(7680)), Attrs: outAttr("memory")}},
-				{Type: Sum, Name: "system.memory.free", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: outAttr("memory")}},
-				{Type: Sum, Name: "system.memory.cached", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(512)), Attrs: outAttr("memory")}},
+				{Type: Sum, Name: "system.memory.total", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(7680)), Attrs: outAttr("memoryscraper")}},
+				{Type: Sum, Name: "system.memory.free", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: outAttr("memoryscraper")}},
+				{Type: Sum, Name: "system.memory.cached", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(512)), Attrs: outAttr("memoryscraper")}},
 				// used = used + buffered + cached as gopsutil calculates used = total - free - buffered - cached
-				{Type: Sum, Name: "system.memory.used.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(5632)), Attrs: outAttr("memory")}},
-				{Type: Sum, Name: "system.memory.actual.used.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(5312)), Attrs: outAttr("memory")}},
-				{Type: Sum, Name: "system.memory.actual.free", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2368)), Attrs: outAttr("memory")}},
-				{Type: Gauge, Name: "system.memory.used.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.734), Attrs: outAttr("memory")}},
-				{Type: Gauge, Name: "system.memory.actual.used.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.69), Attrs: outAttr("memory")}},
+				{Type: Sum, Name: "system.memory.used.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(5632)), Attrs: outAttr("memoryscraper")}},
+				{Type: Sum, Name: "system.memory.actual.used.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(5312)), Attrs: outAttr("memoryscraper")}},
+				{Type: Sum, Name: "system.memory.actual.free", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2368)), Attrs: outAttr("memoryscraper")}},
+				{Type: Gauge, Name: "system.memory.used.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.734), Attrs: outAttr("memoryscraper")}},
+				{Type: Gauge, Name: "system.memory.actual.used.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.69), Attrs: outAttr("memoryscraper")}},
 			},
 		},
 		{
 			name:    "process",
-			scraper: "process",
+			scraper: "processscraper",
 			resourceAttrs: map[string]any{
 				"process.parent_pid":      PPID,
 				"process.owner":           ProcOwner,
@@ -234,27 +234,27 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Sum, Name: "process.disk.operations", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(20)), Attrs: map[string]any{"direction": "write"}}},
 			},
 			expected: []testutils.TestMetric{
-				{Type: Sum, Name: "process.cpu.start_time", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(0)), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.num_threads", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(7)), Attrs: outAttr("process")}},
-				{Type: Gauge, Name: "system.process.memory.rss.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.15), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.memory.rss.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.memory.size", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(128)), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.fd.open", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(10)), Attrs: outAttr("process")}},
-				{Type: Gauge, Name: "process.memory.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.15), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.cpu.total.value", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(1764.3), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.cpu.system.ticks", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(334.5), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.cpu.user.ticks", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(554.6), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.cpu.total.ticks", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(1764.3), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.io.read_bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024)), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.io.write_bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.io.read_ops", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(10)), Attrs: outAttr("process")}},
-				{Type: Sum, Name: "system.process.io.write_ops", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(20)), Attrs: outAttr("process")}},
-				{Type: Gauge, Name: "system.process.cpu.total.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("process")}},
+				{Type: Sum, Name: "process.cpu.start_time", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(0)), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.num_threads", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(7)), Attrs: outAttr("processscraper")}},
+				{Type: Gauge, Name: "system.process.memory.rss.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.15), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.memory.rss.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.memory.size", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(128)), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.fd.open", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(10)), Attrs: outAttr("processscraper")}},
+				{Type: Gauge, Name: "process.memory.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.15), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.cpu.total.value", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(1764.3), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.cpu.system.ticks", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(334.5), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.cpu.user.ticks", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(554.6), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.cpu.total.ticks", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(1764.3), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.io.read_bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024)), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.io.write_bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.io.read_ops", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(10)), Attrs: outAttr("processscraper")}},
+				{Type: Sum, Name: "system.process.io.write_ops", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(20)), Attrs: outAttr("processscraper")}},
+				{Type: Gauge, Name: "system.process.cpu.total.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.0), Attrs: outAttr("processscraper")}},
 			},
 		},
 		{
 			name:    "processes",
-			scraper: "processes",
+			scraper: "processesscraper",
 			input: []testutils.TestMetric{
 				{Type: Sum, Name: "system.processes.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(7)), Attrs: map[string]any{"status": "idle"}}},
 				{Type: Sum, Name: "system.processes.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(3)), Attrs: map[string]any{"status": "sleeping"}}},
@@ -264,17 +264,17 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Sum, Name: "system.processes.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2)), Attrs: map[string]any{"status": "paging"}}},
 			},
 			expected: []testutils.TestMetric{
-				{Type: Sum, Name: "system.process.summary.idle", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(7)), Attrs: outAttr("processes")}},
-				{Type: Sum, Name: "system.process.summary.sleeping", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(3)), Attrs: outAttr("processes")}},
-				{Type: Sum, Name: "system.process.summary.stopped", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(5)), Attrs: outAttr("processes")}},
-				{Type: Sum, Name: "system.process.summary.zombie", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1)), Attrs: outAttr("processes")}},
-				{Type: Sum, Name: "system.process.summary.running", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2)), Attrs: outAttr("processes")}},
-				{Type: Sum, Name: "system.process.summary.total", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(20)), Attrs: outAttr("processes")}},
+				{Type: Sum, Name: "system.process.summary.idle", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(7)), Attrs: outAttr("processesscraper")}},
+				{Type: Sum, Name: "system.process.summary.sleeping", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(3)), Attrs: outAttr("processesscraper")}},
+				{Type: Sum, Name: "system.process.summary.stopped", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(5)), Attrs: outAttr("processesscraper")}},
+				{Type: Sum, Name: "system.process.summary.zombie", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1)), Attrs: outAttr("processesscraper")}},
+				{Type: Sum, Name: "system.process.summary.running", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2)), Attrs: outAttr("processesscraper")}},
+				{Type: Sum, Name: "system.process.summary.total", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(20)), Attrs: outAttr("processesscraper")}},
 			},
 		},
 		{
 			name:    "network",
-			scraper: "network",
+			scraper: "networkscraper",
 			input: []testutils.TestMetric{
 				{Type: Sum, Name: "system.network.io", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024)), Attrs: map[string]any{"device": Device, "direction": "receive"}}},
 				{Type: Sum, Name: "system.network.io", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: map[string]any{"device": Device, "direction": "transmit"}}},
@@ -286,19 +286,19 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Sum, Name: "system.network.errors", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2)), Attrs: map[string]any{"device": Device, "direction": "transmit"}}},
 			},
 			expected: []testutils.TestMetric{
-				{Type: Sum, Name: "system.network.in.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024)), Attrs: outAttr("network")}},
-				{Type: Sum, Name: "system.network.out.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: outAttr("network")}},
-				{Type: Sum, Name: "system.network.in.packets", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(11)), Attrs: outAttr("network")}},
-				{Type: Sum, Name: "system.network.out.packets", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(9)), Attrs: outAttr("network")}},
-				{Type: Sum, Name: "system.network.in.dropped", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(3)), Attrs: outAttr("network")}},
-				{Type: Sum, Name: "system.network.out.dropped", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4)), Attrs: outAttr("network")}},
-				{Type: Sum, Name: "system.network.in.errors", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1)), Attrs: outAttr("network")}},
-				{Type: Sum, Name: "system.network.out.errors", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2)), Attrs: outAttr("network")}},
+				{Type: Sum, Name: "system.network.in.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024)), Attrs: outAttr("networkscraper")}},
+				{Type: Sum, Name: "system.network.out.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: outAttr("networkscraper")}},
+				{Type: Sum, Name: "system.network.in.packets", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(11)), Attrs: outAttr("networkscraper")}},
+				{Type: Sum, Name: "system.network.out.packets", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(9)), Attrs: outAttr("networkscraper")}},
+				{Type: Sum, Name: "system.network.in.dropped", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(3)), Attrs: outAttr("networkscraper")}},
+				{Type: Sum, Name: "system.network.out.dropped", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4)), Attrs: outAttr("networkscraper")}},
+				{Type: Sum, Name: "system.network.in.errors", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1)), Attrs: outAttr("networkscraper")}},
+				{Type: Sum, Name: "system.network.out.errors", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2)), Attrs: outAttr("networkscraper")}},
 			},
 		},
 		{
 			name:    "disk",
-			scraper: "disk",
+			scraper: "diskscraper",
 			input: []testutils.TestMetric{
 				{Type: Sum, Name: "system.disk.io", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1888256)), Attrs: map[string]any{"device": Disk, "direction": "read"}}},
 				{Type: Sum, Name: "system.disk.io", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(512)), Attrs: map[string]any{"device": Disk, "direction": "write"}}},
@@ -310,19 +310,19 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Sum, Name: "system.disk.pending_operations", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(102)), Attrs: map[string]any{"device": Disk}}},
 			},
 			expected: []testutils.TestMetric{
-				{Type: Sum, Name: "system.diskio.read.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1888256)), Attrs: outAttr("disk")}},
-				{Type: Sum, Name: "system.diskio.write.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(512)), Attrs: outAttr("disk")}},
-				{Type: Sum, Name: "system.diskio.read.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(15390)), Attrs: outAttr("disk")}},
-				{Type: Sum, Name: "system.diskio.write.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(371687)), Attrs: outAttr("disk")}},
-				{Type: Sum, Name: "system.diskio.read.time", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(11182.0), Attrs: outAttr("disk")}},
-				{Type: Sum, Name: "system.diskio.write.time", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(617289.0), Attrs: outAttr("disk")}},
-				{Type: Sum, Name: "system.diskio.io.time", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(520300.0), Attrs: outAttr("disk")}},
-				{Type: Sum, Name: "system.diskio.io.ops", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(102)), Attrs: outAttr("disk")}},
+				{Type: Sum, Name: "system.diskio.read.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1888256)), Attrs: outAttr("diskscraper")}},
+				{Type: Sum, Name: "system.diskio.write.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(512)), Attrs: outAttr("diskscraper")}},
+				{Type: Sum, Name: "system.diskio.read.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(15390)), Attrs: outAttr("diskscraper")}},
+				{Type: Sum, Name: "system.diskio.write.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(371687)), Attrs: outAttr("diskscraper")}},
+				{Type: Sum, Name: "system.diskio.read.time", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(11182.0), Attrs: outAttr("diskscraper")}},
+				{Type: Sum, Name: "system.diskio.write.time", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(617289.0), Attrs: outAttr("diskscraper")}},
+				{Type: Sum, Name: "system.diskio.io.time", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(520300.0), Attrs: outAttr("diskscraper")}},
+				{Type: Sum, Name: "system.diskio.io.ops", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(102)), Attrs: outAttr("diskscraper")}},
 			},
 		},
 		{
 			name:    "filesystem",
-			scraper: "filesystem",
+			scraper: "filesystemscraper",
 			input: []testutils.TestMetric{
 				{Type: Sum, Name: "system.filesystem.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(9109504)), Attrs: map[string]any{"device": FilesystemDevice, "mountpoint": mpoint, "type": fstype, "state": "free"}}},
 				{Type: Sum, Name: "system.filesystem.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1337344)), Attrs: map[string]any{"device": FilesystemDevice, "mountpoint": mpoint, "type": fstype, "state": "used"}}},
@@ -330,13 +330,13 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 				{Type: Sum, Name: "system.filesystem.inodes.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(216763)), Attrs: map[string]any{"device": FilesystemDevice, "mountpoint": mpoint, "type": fstype, "state": "used"}}},
 			},
 			expected: []testutils.TestMetric{
-				{Type: Sum, Name: "system.filesystem.free", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(9109504)), Attrs: outAttr("filesystem")}},
-				{Type: Sum, Name: "system.filesystem.available", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(9109504)), Attrs: outAttr("filesystem")}},
-				{Type: Sum, Name: "system.filesystem.used.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1337344)), Attrs: outAttr("filesystem")}},
-				{Type: Sum, Name: "system.filesystem.free_files", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(3898597)), Attrs: outAttr("filesystem")}},
-				{Type: Sum, Name: "system.filesystem.total", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(10446848)), Attrs: outAttr("filesystem")}},
-				{Type: Sum, Name: "system.filesystem.used.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.1280141149), Attrs: outAttr("filesystem")}},
-				{Type: Sum, Name: "system.filesystem.files", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4115360)), Attrs: outAttr("filesystem")}},
+				{Type: Sum, Name: "system.filesystem.free", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(9109504)), Attrs: outAttr("filesystemscraper")}},
+				{Type: Sum, Name: "system.filesystem.available", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(9109504)), Attrs: outAttr("filesystemscraper")}},
+				{Type: Sum, Name: "system.filesystem.used.bytes", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1337344)), Attrs: outAttr("filesystemscraper")}},
+				{Type: Sum, Name: "system.filesystem.free_files", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(3898597)), Attrs: outAttr("filesystemscraper")}},
+				{Type: Sum, Name: "system.filesystem.total", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(10446848)), Attrs: outAttr("filesystemscraper")}},
+				{Type: Sum, Name: "system.filesystem.used.pct", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.1280141149), Attrs: outAttr("filesystemscraper")}},
+				{Type: Sum, Name: "system.filesystem.files", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4115360)), Attrs: outAttr("filesystemscraper")}},
 			},
 		},
 	} {
@@ -359,7 +359,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 func BenchmarkRemap(b *testing.B) {
 	now := pcommon.NewTimestampFromTime(time.Now())
 	in := map[string][]testutils.TestMetric{
-		"cpu": []testutils.TestMetric{
+		"cpu": {
 			{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.26), Attrs: map[string]any{"cpu": "cpu0", "state": "user"}}},
 			{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.24), Attrs: map[string]any{"cpu": "cpu0", "state": "system"}}},
 			{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.5), Attrs: map[string]any{"cpu": "cpu0", "state": "idle"}}},
@@ -370,12 +370,12 @@ func BenchmarkRemap(b *testing.B) {
 			{Type: Gauge, Name: "system.cpu.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.05), Attrs: map[string]any{"cpu": "cpu1", "state": "steal"}}},
 			{Type: Sum, Name: "system.cpu.logical.count", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(4))}},
 		},
-		"load": []testutils.TestMetric{
+		"load": {
 			{Type: Gauge, Name: "system.cpu.load_average.1m", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.14)}},
 			{Type: Gauge, Name: "system.cpu.load_average.5m", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.12)}},
 			{Type: Gauge, Name: "system.cpu.load_average.15m", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.05)}},
 		},
-		"memory": []testutils.TestMetric{
+		"memory": {
 			{Type: Sum, Name: "system.memory.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024)), Attrs: map[string]any{"state": "buffered"}}},
 			{Type: Sum, Name: "system.memory.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(512)), Attrs: map[string]any{"state": "cached"}}},
 			{Type: Sum, Name: "system.memory.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(256)), Attrs: map[string]any{"state": "inactive"}}},
@@ -391,7 +391,7 @@ func BenchmarkRemap(b *testing.B) {
 			{Type: Gauge, Name: "system.memory.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.008), Attrs: map[string]any{"state": "slab_unreclaimable"}}},
 			{Type: Gauge, Name: "system.memory.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.533), Attrs: map[string]any{"state": "used"}}},
 		},
-		"process": []testutils.TestMetric{
+		"process": {
 			{Type: Sum, Name: "process.threads", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(7))}},
 			{Type: Gauge, Name: "process.memory.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(15.0)}},
 			{Type: Sum, Name: "process.memory.usage", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048))}},
@@ -403,7 +403,7 @@ func BenchmarkRemap(b *testing.B) {
 			{Type: Sum, Name: "process.disk.io", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024))}},
 			{Type: Sum, Name: "process.disk.operations", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(10))}},
 		},
-		"network": []testutils.TestMetric{
+		"network": {
 			{Type: Sum, Name: "system.network.io", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(1024)), Attrs: map[string]any{"device": Device, "direction": "receive"}}},
 			{Type: Sum, Name: "system.network.io", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(2048)), Attrs: map[string]any{"device": Device, "direction": "transmit"}}},
 			{Type: Sum, Name: "system.network.packets", DP: testutils.TestDP{Ts: now, Int: testutils.Ptr(int64(11)), Attrs: map[string]any{"device": Device, "direction": "receive"}}},

--- a/remappers/kubernetesmetrics/k8smetrics.go
+++ b/remappers/kubernetesmetrics/k8smetrics.go
@@ -27,6 +27,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	kubeletScopePrefix = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
+	clusterScopePrefix = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
+)
+
 var scraperToElasticDataset = map[string]string{
 	"kubeletstatsreceiver": "kubernetes.pod",
 	"k8sclusterreceiver":   "kubernetes.node",
@@ -103,6 +108,6 @@ func (r *Remapper) Remap(
 // Valid validates a ScopeMetric against the kubernetes metrics remapper requirements.
 // Kubernetes remapper only remaps metrics from kubeletstatsreceiver or k8sclusterreceiver.
 func (r *Remapper) Valid(sm pmetric.ScopeMetrics) bool {
-	return strings.HasPrefix(sm.Scope().Name(), "otelcol/kubeletstatsreceiver") ||
-		strings.HasPrefix(sm.Scope().Name(), "otelcol/k8sclusterreceiver")
+	return strings.HasPrefix(sm.Scope().Name(), kubeletScopePrefix) ||
+		strings.HasPrefix(sm.Scope().Name(), clusterScopePrefix)
 }

--- a/remappers/kubernetesmetrics/k8smetrics_test.go
+++ b/remappers/kubernetesmetrics/k8smetrics_test.go
@@ -33,7 +33,7 @@ import (
 var (
 	Sum         = pmetric.MetricTypeSum
 	Gauge       = pmetric.MetricTypeGauge
-	scopePrefix = "otelcol/kubeletstatsreceiver"
+	scopePrefix = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
 	// Test values to make assertion easier
 	POD              = "pod0"
 	NAMESPACE        = "kube-system"
@@ -115,7 +115,7 @@ func doTestRemap(t *testing.T, id string, remapOpts ...Option) {
 func BenchmarkRemap(b *testing.B) {
 	now := pcommon.NewTimestampFromTime(time.Now())
 	in := map[string][]testutils.TestMetric{
-		"kubeletstatsreceiver": []testutils.TestMetric{
+		"kubeletstatsreceiver": {
 			{Type: Gauge, Name: "k8s.pod.cpu_limit_utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.26), Attrs: map[string]any{"k8s.pod.name": POD, "k8s.namespace.name": NAMESPACE}}},
 			{Type: Gauge, Name: "k8s.pod.cpu.node.utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.12), Attrs: map[string]any{"k8s.pod.name": POD, "k8s.namespace.name": NAMESPACE}}},
 			{Type: Gauge, Name: "k8s.pod.memory_limit_utilization", DP: testutils.TestDP{Ts: now, Dbl: testutils.Ptr(0.18), Attrs: map[string]any{"k8s.pod.name": "pod0", "k8s.pod.namespace": NAMESPACE}}},


### PR DESCRIPTION
Scraper names were changed in v0.107.0: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34526/files

Breaking change: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.107.0