### PR TITLE
Add enrichment for error.grouping_name

### DIFF
--- a/enrichments/trace/config/config.go
+++ b/enrichments/trace/config/config.go
@@ -88,9 +88,7 @@ type SpanEventConfig struct {
 	ErrorID               AttributeConfig `mapstructure:"error_id"`
 	ErrorExceptionHandled AttributeConfig `mapstructure:"error_exception_handled"`
 	ErrorGroupingKey      AttributeConfig `mapstructure:"error_grouping_key"`
-
-	// For no exceptions/errors
-	EventKind AttributeConfig `mapstructure:"event_kind"`
+	ErrorGroupingName     AttributeConfig `mapstructure:"error_grouping_name"`
 }
 
 // AttributeConfig is the configuration options for each attribute.
@@ -141,7 +139,7 @@ func Enabled() Config {
 			ErrorID:               AttributeConfig{Enabled: true},
 			ErrorExceptionHandled: AttributeConfig{Enabled: true},
 			ErrorGroupingKey:      AttributeConfig{Enabled: true},
-			EventKind:             AttributeConfig{Enabled: true},
+			ErrorGroupingName:     AttributeConfig{Enabled: true},
 		},
 	}
 }

--- a/enrichments/trace/internal/elastic/attributes.go
+++ b/enrichments/trace/internal/elastic/attributes.go
@@ -53,4 +53,5 @@ const (
 	AttributeErrorID               = "error.id"
 	AttributeErrorExceptionHandled = "error.exception.handled"
 	AttributeErrorGroupingKey      = "error.grouping_key"
+	AttributeErrorGroupingName     = "error.grouping_name"
 )

--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -491,6 +491,11 @@ func (s *spanEventEnrichmentContext) enrich(
 		}
 		se.Attributes().PutStr(AttributeErrorGroupingKey, hex.EncodeToString(hash.Sum(nil)))
 	}
+	if cfg.ErrorGroupingName.Enabled {
+		if s.exceptionMessage != "" {
+			se.Attributes().PutStr(AttributeErrorGroupingName, s.exceptionMessage)
+		}
+	}
 
 	// Transaction type and sampled are added as span event enrichment only for errors
 	if parentCtx.isTransaction && s.exception {

--- a/enrichments/trace/internal/elastic/span_test.go
+++ b/enrichments/trace/internal/elastic/span_test.go
@@ -811,6 +811,7 @@ func TestSpanEventEnrich(t *testing.T) {
 					hash.Write([]byte("java.net.ConnectionError"))
 					return hex.EncodeToString(hash.Sum(nil))
 				}(),
+				AttributeErrorGroupingName:  "something is wrong",
 				AttributeTransactionSampled: true,
 				AttributeTransactionType:    "unknown",
 			},
@@ -843,6 +844,7 @@ func TestSpanEventEnrich(t *testing.T) {
 					hash.Write([]byte("java.net.ConnectionError"))
 					return hex.EncodeToString(hash.Sum(nil))
 				}(),
+				AttributeErrorGroupingName: "something is wrong",
 			},
 		},
 	} {


### PR DESCRIPTION
`error.grouping_name` is set in APM using an ingest-pipeline: https://github.com/elastic/elasticsearch/blob/a18b3313364b6b7c87c45bae9dc342dec314966d/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error%40mappings.yaml#L25-L42. For OTel, based on apm-data logic, it basically translates to a 1<>1 mapping for `error.exception.message`. However, it is derived in nature and could its definition could be extended in future so keeping it as enrichment - let me know if there are any concerns.

Related to: https://github.com/elastic/opentelemetry-dev/issues/317