### PR TITLE
[enrichments]Allow overriding host name with k8s node name

### DIFF
--- a/enrichments/trace/config/config.go
+++ b/enrichments/trace/config/config.go
@@ -28,8 +28,9 @@ type Config struct {
 
 // ResourceConfig configures the enrichment of resource attributes.
 type ResourceConfig struct {
-	AgentName    AttributeConfig `mapstructure:"agent_name"`
-	AgentVersion AttributeConfig `mapstructure:"agent_version"`
+	AgentName        AttributeConfig `mapstructure:"agent_name"`
+	AgentVersion     AttributeConfig `mapstructure:"agent_version"`
+	OverrideHostName AttributeConfig `mapstructure:"override_host_name"`
 }
 
 // ScopeConfig configures the enrichment of scope attributes.
@@ -100,8 +101,9 @@ type AttributeConfig struct {
 func Enabled() Config {
 	return Config{
 		Resource: ResourceConfig{
-			AgentName:    AttributeConfig{Enabled: true},
-			AgentVersion: AttributeConfig{Enabled: true},
+			AgentName:        AttributeConfig{Enabled: true},
+			AgentVersion:     AttributeConfig{Enabled: true},
+			OverrideHostName: AttributeConfig{Enabled: true},
 		},
 		Scope: ScopeConfig{
 			ServiceFrameworkName:    AttributeConfig{Enabled: true},

--- a/enrichments/trace/internal/elastic/resource_test.go
+++ b/enrichments/trace/internal/elastic/resource_test.go
@@ -162,6 +162,37 @@ func TestResourceEnrich(t *testing.T) {
 				AttributeAgentVersion: "1.2.3",
 			},
 		},
+		{
+			name: "host_name_override_with_k8s_node_name",
+			input: func() pcommon.Resource {
+				res := pcommon.NewResource()
+				res.Attributes().PutStr(semconv.AttributeHostName, "test-host")
+				res.Attributes().PutStr(semconv.AttributeK8SNodeName, "k8s-node")
+				return res
+			}(),
+			config: config.Enabled().Resource,
+			enrichedAttrs: map[string]any{
+				semconv.AttributeHostName:    "k8s-node",
+				semconv.AttributeK8SNodeName: "k8s-node",
+				AttributeAgentName:           "otlp",
+				AttributeAgentVersion:        "unknown",
+			},
+		},
+		{
+			name: "host_name_if_empty_set_from_k8s_node_name",
+			input: func() pcommon.Resource {
+				res := pcommon.NewResource()
+				res.Attributes().PutStr(semconv.AttributeK8SNodeName, "k8s-node")
+				return res
+			}(),
+			config: config.Enabled().Resource,
+			enrichedAttrs: map[string]any{
+				semconv.AttributeHostName:    "k8s-node",
+				semconv.AttributeK8SNodeName: "k8s-node",
+				AttributeAgentName:           "otlp",
+				AttributeAgentVersion:        "unknown",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Merge existing resource attrs with the attrs added


### PR DESCRIPTION
	// Host name is set same as k8s node name. In case, both host name
	// and k8s node name are set then host name is overridden as this is
	// considered an invalid configuration/smell and k8s node name is
	// given higher preference.

For more context: https://elastic.slack.com/archives/C07Q1CVD9MW/p1728487638317189