### PR TITLE
Add support for http.url to identify url full

### DIFF
--- a/enrichments/trace/internal/elastic/resource.go
+++ b/enrichments/trace/internal/elastic/resource.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/elastic/opentelemetry-lib/enrichments/trace/config"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/collector/semconv/v1.22.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.25.0"
 )
 
 // EnrichResource derives and adds Elastic specific resource attributes.

--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -108,13 +108,13 @@ func (s *spanEnrichmentContext) Enrich(span ptrace.Span, cfg config.Config) {
 			s.httpStatusCode = v.Int()
 		case semconv.AttributeHTTPMethod,
 			semconv.AttributeHTTPRequestMethod,
-			semconv.AttributeHTTPURL,
 			semconv.AttributeHTTPTarget,
 			semconv.AttributeHTTPScheme,
 			semconv.AttributeHTTPFlavor,
 			semconv.AttributeNetHostName:
 			s.isHTTP = true
-		case semconv.AttributeURLFull:
+		case semconv.AttributeURLFull,
+			semconv.AttributeHTTPURL:
 			s.isHTTP = true
 			// ignoring error as if parse fails then we don't want the url anyway
 			s.urlFull, _ = url.Parse(v.Str())


### PR DESCRIPTION
`http.url` is still being used. This PR adds support for the now deprecated `http.url` in addition to `url.full`. There are a couple more attributes for `net.peer.*` which I am working on resolving.

Related to: https://github.com/elastic/opentelemetry-dev/issues/490