### PR TITLE
Support service.{address, port} with fallback to net.peer.*

### DIFF
--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -611,9 +611,6 @@ func getValueForKeyInString(str string, key string, separator rune, assignChar r
 	return ""
 }
 
-// getHostPort derives the host:port value from url.* attributes. Unlike
-// apm-data, the current code does NOT fallback to net.* or http.*
-// attributes as most of these are now deprecated.
 func getHostPort(
 	urlFull *url.URL, urlDomain string, urlPort int64,
 	fallbackServerAddress string, fallbackServerPort int64,

--- a/enrichments/trace/internal/elastic/span_test.go
+++ b/enrichments/trace/internal/elastic/span_test.go
@@ -633,6 +633,58 @@ func TestElasticSpanEnrich(t *testing.T) {
 			},
 		},
 		{
+			name: "rpc_span_service.{address, port}",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("testspan")
+				// No peer.service is set
+				span.Attributes().PutStr(semconv.AttributeRPCService, "service.Test")
+				span.Attributes().PutStr(semconv.AttributeServerAddress, "10.2.20.18")
+				span.Attributes().PutInt(semconv.AttributeServerPort, 8081)
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				AttributeTimestampUs:                    startTs.AsTime().UnixMicro(),
+				AttributeSpanName:                       "testspan",
+				AttributeProcessorEvent:                 "span",
+				AttributeSpanRepresentativeCount:        float64(1),
+				AttributeSpanType:                       "external",
+				AttributeSpanDurationUs:                 expectedDuration.Microseconds(),
+				AttributeEventOutcome:                   "success",
+				AttributeSuccessCount:                   int64(1),
+				AttributeServiceTargetType:              "external",
+				AttributeServiceTargetName:              "service.Test",
+				AttributeSpanDestinationServiceResource: "10.2.20.18:8081",
+			},
+		},
+		{
+			name: "rpc_span_net.peer.{address, port}_fallback",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("testspan")
+				// No peer.service is set
+				span.Attributes().PutStr(semconv.AttributeRPCService, "service.Test")
+				span.Attributes().PutStr(semconv.AttributeNetPeerName, "10.2.20.18")
+				span.Attributes().PutInt(semconv.AttributeNetPeerPort, 8081)
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				AttributeTimestampUs:                    startTs.AsTime().UnixMicro(),
+				AttributeSpanName:                       "testspan",
+				AttributeProcessorEvent:                 "span",
+				AttributeSpanRepresentativeCount:        float64(1),
+				AttributeSpanType:                       "external",
+				AttributeSpanDurationUs:                 expectedDuration.Microseconds(),
+				AttributeEventOutcome:                   "success",
+				AttributeSuccessCount:                   int64(1),
+				AttributeServiceTargetType:              "external",
+				AttributeServiceTargetName:              "service.Test",
+				AttributeSpanDestinationServiceResource: "10.2.20.18:8081",
+			},
+		},
+		{
 			name: "messaging_basic",
 			input: func() ptrace.Span {
 				span := getElasticSpan()


### PR DESCRIPTION
`service.{address, port}` is used to calculate service destination when `url.*` attributes are not present. The logic fallback to use the now deprecated `net.peer.{name, port}` if `service.{address, port}` are not present.

Related to: https://github.com/elastic/opentelemetry-dev/issues/490