### PR TITLE
Enrich root spans that represent a dependency

### DIFF
--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -196,6 +196,7 @@ func (s *spanEnrichmentContext) Enrich(span ptrace.Span, cfg config.Config) {
 func (s *spanEnrichmentContext) enrich(span ptrace.Span, cfg config.Config) {
 	if s.isTransaction {
 		s.enrichTransaction(span, cfg.Transaction)
+		s.enrichExitSpanTransaction(span, cfg)
 	} else {
 		s.enrichSpan(span, cfg.Span)
 	}
@@ -241,6 +242,39 @@ func (s *spanEnrichmentContext) enrichTransaction(
 	}
 	if cfg.InferredSpans.Enabled {
 		s.setInferredSpans(span)
+	}
+}
+
+// In OTel a root span can represent an outgoing call or a producer span
+// In such cases, the span is still mapped into a transaction, but such spans are enriched
+// with additional attributes that are specific to the outgoing call or producer span.
+func (s *spanEnrichmentContext) enrichExitSpanTransaction(
+	span ptrace.Span,
+	cfg config.Config,
+) {
+	if span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer {
+		if cfg.Span.TypeSubtype.Enabled {
+			s.setSpanTypeSubtype(span)
+		}
+		if cfg.Span.ServiceTarget.Enabled {
+			s.setServiceTarget(span)
+		}
+		if cfg.Span.DestinationService.Enabled {
+			s.setDestinationService(span)
+		}
+		if cfg.Span.Name.Enabled {
+			span.Attributes().PutStr(AttributeSpanName, span.Name())
+		}
+		if cfg.Transaction.Type.Enabled {
+			spanTypeAttr, hasType := span.Attributes().Get(AttributeSpanType)
+			if hasType {
+				transactionType := spanTypeAttr.Str()
+				if spanSubtypeAttr, hasSubType := span.Attributes().Get(AttributeSpanSubtype); hasSubType {
+					transactionType += "." + spanSubtypeAttr.Str()
+				}
+				span.Attributes().PutStr(AttributeTransactionType, transactionType)
+			}
+		}
 	}
 }
 

--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -251,39 +251,6 @@ func (s *spanEnrichmentContext) enrichTransaction(
 	}
 }
 
-// In OTel, a local span can represent an outgoing call or a producer span.
-// In such cases, the span is still mapped into a transaction, but enriched
-// with additional attributes that are specific to the outgoing call or producer span.
-func (s *spanEnrichmentContext) enrichExitSpanTransaction(
-	span ptrace.Span,
-	cfg config.Config,
-) {
-	if span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer {
-		if cfg.Span.TypeSubtype.Enabled {
-			s.setSpanTypeSubtype(span)
-		}
-		if cfg.Span.ServiceTarget.Enabled {
-			s.setServiceTarget(span)
-		}
-		if cfg.Span.DestinationService.Enabled {
-			s.setDestinationService(span)
-		}
-		if cfg.Span.Name.Enabled {
-			span.Attributes().PutStr(AttributeSpanName, span.Name())
-		}
-		if cfg.Transaction.Type.Enabled {
-			spanTypeAttr, hasType := span.Attributes().Get(AttributeSpanType)
-			if hasType {
-				transactionType := spanTypeAttr.Str()
-				if spanSubtypeAttr, hasSubType := span.Attributes().Get(AttributeSpanSubtype); hasSubType {
-					transactionType += "." + spanSubtypeAttr.Str()
-				}
-				span.Attributes().PutStr(AttributeTransactionType, transactionType)
-			}
-		}
-	}
-}
-
 func (s *spanEnrichmentContext) enrichSpan(
 	span ptrace.Span,
 	cfg config.Config,

--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -256,13 +256,13 @@ func (s *spanEnrichmentContext) enrichSpan(
 	cfg config.Config,
 	isExitRootSpan bool,
 ) {
-	if cfg.TimestampUs.Enabled {
+	if cfg.Span.TimestampUs.Enabled {
 		span.Attributes().PutInt(elasticattr.TimestampUs, getTimestampUs(span.StartTimestamp()))
 	}
-	if cfg.Name.Enabled {
+	if cfg.Span.Name.Enabled {
 		span.Attributes().PutStr(elasticattr.SpanName, span.Name())
 	}
-	if cfg.RepresentativeCount.Enabled {
+	if cfg.Span.RepresentativeCount.Enabled {
 		repCount := getRepresentativeCount(span.TraceState().AsRaw())
 		span.Attributes().PutDouble(elasticattr.SpanRepresentativeCount, repCount)
 	}
@@ -272,7 +272,7 @@ func (s *spanEnrichmentContext) enrichSpan(
 	if cfg.Span.EventOutcome.Enabled {
 		s.setEventOutcome(span)
 	}
-	if cfg.DurationUs.Enabled {
+	if cfg.Span.DurationUs.Enabled {
 		span.Attributes().PutInt(elasticattr.SpanDurationUs, getDurationUs(span))
 	}
 	if cfg.Span.ServiceTarget.Enabled {
@@ -285,17 +285,17 @@ func (s *spanEnrichmentContext) enrichSpan(
 		s.setInferredSpans(span)
 	}
 	if cfg.Span.ProcessorEvent.Enabled && !isExitRootSpan {
-		span.Attributes().PutStr(AttributeProcessorEvent, "span")
+		span.Attributes().PutStr(elasticattr.ProcessorEvent, "span")
 	}
 
 	if isExitRootSpan && cfg.Transaction.Type.Enabled {
-		spanTypeAttr, hasType := span.Attributes().Get(AttributeSpanType)
+		spanTypeAttr, hasType := span.Attributes().Get(elasticattr.SpanType)
 		if hasType {
 			transactionType := spanTypeAttr.Str()
-			if spanSubtypeAttr, hasSubType := span.Attributes().Get(AttributeSpanSubtype); hasSubType {
+			if spanSubtypeAttr, hasSubType := span.Attributes().Get(elasticattr.SpanSubtype); hasSubType {
 				transactionType += "." + spanSubtypeAttr.Str()
 			}
-			span.Attributes().PutStr(AttributeTransactionType, transactionType)
+			span.Attributes().PutStr(elasticattr.TransactionType, transactionType)
 		}
 	}
 }

--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -284,14 +284,8 @@ func (s *spanEnrichmentContext) enrichSpan(
 	if cfg.Span.InferredSpans.Enabled {
 		s.setInferredSpans(span)
 	}
-	if cfg.Span.ProcessorEvent.Enabled {
-		if isExitRootSpan {
-			attrSlice := span.Attributes().PutEmptySlice(AttributeProcessorEvent)
-			attrSlice.AppendEmpty().SetStr("transaction")
-			attrSlice.AppendEmpty().SetStr("span")
-		} else {
-			span.Attributes().PutStr(AttributeProcessorEvent, "span")
-		}
+	if cfg.Span.ProcessorEvent.Enabled && !isExitRootSpan {
+		span.Attributes().PutStr(AttributeProcessorEvent, "span")
 	}
 
 	if isExitRootSpan && cfg.Transaction.Type.Enabled {

--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -284,8 +284,14 @@ func (s *spanEnrichmentContext) enrichSpan(
 	if cfg.Span.InferredSpans.Enabled {
 		s.setInferredSpans(span)
 	}
-	if cfg.Span.ProcessorEvent.Enabled && !isExitRootSpan {
-		span.Attributes().PutStr(AttributeProcessorEvent, "span")
+	if cfg.Span.ProcessorEvent.Enabled {
+		if isExitRootSpan {
+			attrSlice := span.Attributes().PutEmptySlice(AttributeProcessorEvent)
+			attrSlice.AppendEmpty().SetStr("transaction")
+			attrSlice.AppendEmpty().SetStr("span")
+		} else {
+			span.Attributes().PutStr(AttributeProcessorEvent, "span")
+		}
 	}
 
 	if isExitRootSpan && cfg.Transaction.Type.Enabled {

--- a/enrichments/trace/internal/elastic/span_test.go
+++ b/enrichments/trace/internal/elastic/span_test.go
@@ -412,9 +412,14 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:                    int64(0),
-				AttributeTransactionName:                "rootClientSpan",
-				AttributeProcessorEvent:                 "transaction",
+				AttributeTimestampUs:     int64(0),
+				AttributeTransactionName: "rootClientSpan",
+				AttributeProcessorEvent: func() pcommon.Slice {
+					p := pcommon.NewSlice()
+					p.AppendEmpty().SetStr("transaction")
+					p.AppendEmpty().SetStr("span")
+					return p
+				}().AsRaw(),
 				AttributeSpanType:                       "external",
 				AttributeSpanSubtype:                    "http",
 				AttributeSpanDestinationServiceResource: "localhost:8080",
@@ -450,9 +455,14 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:                    int64(0),
-				AttributeTransactionName:                "rootClientSpan",
-				AttributeProcessorEvent:                 "transaction",
+				AttributeTimestampUs:     int64(0),
+				AttributeTransactionName: "rootClientSpan",
+				AttributeProcessorEvent: func() pcommon.Slice {
+					p := pcommon.NewSlice()
+					p.AppendEmpty().SetStr("transaction")
+					p.AppendEmpty().SetStr("span")
+					return p
+				}().AsRaw(),
 				AttributeSpanType:                       "db",
 				AttributeSpanSubtype:                    "mssql",
 				AttributeSpanDestinationServiceResource: "mssql",
@@ -490,9 +500,14 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:                    int64(0),
-				AttributeTransactionName:                "rootClientSpan",
-				AttributeProcessorEvent:                 "transaction",
+				AttributeTimestampUs:     int64(0),
+				AttributeTransactionName: "rootClientSpan",
+				AttributeProcessorEvent: func() pcommon.Slice {
+					p := pcommon.NewSlice()
+					p.AppendEmpty().SetStr("transaction")
+					p.AppendEmpty().SetStr("span")
+					return p
+				}().AsRaw(),
 				AttributeSpanType:                       "messaging",
 				AttributeSpanSubtype:                    "rabbitmq",
 				AttributeSpanDestinationServiceResource: "rabbitmq/T",

--- a/enrichments/trace/internal/elastic/span_test.go
+++ b/enrichments/trace/internal/elastic/span_test.go
@@ -404,34 +404,34 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 				span.SetName("rootClientSpan")
 				span.SetSpanID([8]byte{1})
 				span.SetKind(ptrace.SpanKindClient)
-				span.Attributes().PutStr(semconv.AttributeHTTPMethod, "GET")
-				span.Attributes().PutStr(semconv.AttributeHTTPURL, "http://localhost:8080")
-				span.Attributes().PutInt(semconv.AttributeHTTPResponseStatusCode, 200)
-				span.Attributes().PutStr(semconv.AttributeNetworkProtocolVersion, "1.1")
+				span.Attributes().PutStr(semconv27.AttributeHTTPRequestMethod, "GET")
+				span.Attributes().PutStr(semconv27.AttributeURLFull, "http://localhost:8080")
+				span.Attributes().PutInt(semconv27.AttributeHTTPResponseStatusCode, 200)
+				span.Attributes().PutStr(semconv27.AttributeNetworkProtocolVersion, "1.1")
 				return span
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:                    int64(0),
-				AttributeTransactionName:                "rootClientSpan",
-				AttributeProcessorEvent:                 "transaction",
-				AttributeSpanType:                       "external",
-				AttributeSpanSubtype:                    "http",
-				AttributeSpanDestinationServiceResource: "localhost:8080",
-				AttributeSpanName:                       "rootClientSpan",
-				AttributeEventOutcome:                   "success",
-				AttributeSuccessCount:                   int64(1),
-				AttributeServiceTargetName:              "localhost:8080",
-				AttributeServiceTargetType:              "http",
-				AttributeTransactionID:                  "0100000000000000",
-				AttributeTransactionDurationUs:          int64(0),
-				AttributeTransactionRepresentativeCount: float64(1),
-				AttributeTransactionResult:              "HTTP 2xx",
-				AttributeTransactionType:                "external.http",
-				AttributeTransactionSampled:             true,
-				AttributeTransactionRoot:                true,
-				AttributeSpanDurationUs:                 int64(0),
-				AttributeSpanRepresentativeCount:        float64(1),
+				elasticattr.TimestampUs:                    int64(0),
+				elasticattr.TransactionName:                "rootClientSpan",
+				elasticattr.ProcessorEvent:                 "transaction",
+				elasticattr.SpanType:                       "external",
+				elasticattr.SpanSubtype:                    "http",
+				elasticattr.SpanDestinationServiceResource: "localhost:8080",
+				elasticattr.SpanName:                       "rootClientSpan",
+				elasticattr.EventOutcome:                   "success",
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.ServiceTargetName:              "localhost:8080",
+				elasticattr.ServiceTargetType:              "http",
+				elasticattr.TransactionID:                  "0100000000000000",
+				elasticattr.TransactionDurationUs:          int64(0),
+				elasticattr.TransactionRepresentativeCount: float64(1),
+				elasticattr.TransactionResult:              "HTTP 2xx",
+				elasticattr.TransactionType:                "external.http",
+				elasticattr.TransactionSampled:             true,
+				elasticattr.TransactionRoot:                true,
+				elasticattr.SpanDurationUs:                 int64(0),
+				elasticattr.SpanRepresentativeCount:        float64(1),
 			},
 		},
 		{
@@ -441,35 +441,35 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 				span.SetName("rootClientSpan")
 				span.SetSpanID([8]byte{1})
 				span.SetKind(ptrace.SpanKindClient)
-				span.Attributes().PutStr(semconv.AttributeDBSystem, "mssql")
+				span.Attributes().PutStr(semconv25.AttributeDBSystem, "mssql")
 
-				span.Attributes().PutStr(semconv.AttributeDBName, "myDb")
-				span.Attributes().PutStr(semconv.AttributeDBOperation, "SELECT")
-				span.Attributes().PutStr(semconv.AttributeDBStatement, "SELECT * FROM wuser_table")
+				span.Attributes().PutStr(semconv25.AttributeDBName, "myDb")
+				span.Attributes().PutStr(semconv25.AttributeDBOperation, "SELECT")
+				span.Attributes().PutStr(semconv25.AttributeDBStatement, "SELECT * FROM wuser_table")
 				return span
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:                    int64(0),
-				AttributeTransactionName:                "rootClientSpan",
-				AttributeProcessorEvent:                 "transaction",
-				AttributeSpanType:                       "db",
-				AttributeSpanSubtype:                    "mssql",
-				AttributeSpanDestinationServiceResource: "mssql",
-				AttributeSpanName:                       "rootClientSpan",
-				AttributeEventOutcome:                   "success",
-				AttributeSuccessCount:                   int64(1),
-				AttributeServiceTargetName:              "myDb",
-				AttributeServiceTargetType:              "mssql",
-				AttributeTransactionID:                  "0100000000000000",
-				AttributeTransactionDurationUs:          int64(0),
-				AttributeTransactionRepresentativeCount: float64(1),
-				AttributeTransactionResult:              "Success",
-				AttributeTransactionType:                "db.mssql",
-				AttributeTransactionSampled:             true,
-				AttributeTransactionRoot:                true,
-				AttributeSpanDurationUs:                 int64(0),
-				AttributeSpanRepresentativeCount:        float64(1),
+				elasticattr.TimestampUs:                    int64(0),
+				elasticattr.TransactionName:                "rootClientSpan",
+				elasticattr.ProcessorEvent:                 "transaction",
+				elasticattr.SpanType:                       "db",
+				elasticattr.SpanSubtype:                    "mssql",
+				elasticattr.SpanDestinationServiceResource: "mssql",
+				elasticattr.SpanName:                       "rootClientSpan",
+				elasticattr.EventOutcome:                   "success",
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.ServiceTargetName:              "myDb",
+				elasticattr.ServiceTargetType:              "mssql",
+				elasticattr.TransactionID:                  "0100000000000000",
+				elasticattr.TransactionDurationUs:          int64(0),
+				elasticattr.TransactionRepresentativeCount: float64(1),
+				elasticattr.TransactionResult:              "Success",
+				elasticattr.TransactionType:                "db.mssql",
+				elasticattr.TransactionSampled:             true,
+				elasticattr.TransactionRoot:                true,
+				elasticattr.SpanDurationUs:                 int64(0),
+				elasticattr.SpanRepresentativeCount:        float64(1),
 			},
 		},
 		{
@@ -480,36 +480,36 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 				span.SetSpanID([8]byte{1})
 				span.SetKind(ptrace.SpanKindProducer)
 
-				span.Attributes().PutStr(semconv.AttributeServerAddress, "myServer")
-				span.Attributes().PutStr(semconv.AttributeServerPort, "1234")
-				span.Attributes().PutStr(semconv.AttributeMessagingSystem, "rabbitmq")
-				span.Attributes().PutStr(semconv.AttributeMessagingDestinationName, "T")
-				span.Attributes().PutStr(semconv.AttributeMessagingOperation, "publish")
-				span.Attributes().PutStr(semconv.AttributeMessagingClientID, "a")
+				span.Attributes().PutStr(semconv25.AttributeServerAddress, "myServer")
+				span.Attributes().PutStr(semconv25.AttributeServerPort, "1234")
+				span.Attributes().PutStr(semconv25.AttributeMessagingSystem, "rabbitmq")
+				span.Attributes().PutStr(semconv25.AttributeMessagingDestinationName, "T")
+				span.Attributes().PutStr(semconv25.AttributeMessagingOperation, "publish")
+				span.Attributes().PutStr(semconv25.AttributeMessagingClientID, "a")
 				return span
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:                    int64(0),
-				AttributeTransactionName:                "rootClientSpan",
-				AttributeProcessorEvent:                 "transaction",
-				AttributeSpanType:                       "messaging",
-				AttributeSpanSubtype:                    "rabbitmq",
-				AttributeSpanDestinationServiceResource: "rabbitmq/T",
-				AttributeSpanName:                       "rootClientSpan",
-				AttributeEventOutcome:                   "success",
-				AttributeSuccessCount:                   int64(1),
-				AttributeServiceTargetName:              "T",
-				AttributeServiceTargetType:              "rabbitmq",
-				AttributeTransactionID:                  "0100000000000000",
-				AttributeTransactionDurationUs:          int64(0),
-				AttributeTransactionRepresentativeCount: float64(1),
-				AttributeTransactionResult:              "Success",
-				AttributeTransactionType:                "messaging.rabbitmq",
-				AttributeTransactionSampled:             true,
-				AttributeTransactionRoot:                true,
-				AttributeSpanDurationUs:                 int64(0),
-				AttributeSpanRepresentativeCount:        float64(1),
+				elasticattr.TimestampUs:                    int64(0),
+				elasticattr.TransactionName:                "rootClientSpan",
+				elasticattr.ProcessorEvent:                 "transaction",
+				elasticattr.SpanType:                       "messaging",
+				elasticattr.SpanSubtype:                    "rabbitmq",
+				elasticattr.SpanDestinationServiceResource: "rabbitmq/T",
+				elasticattr.SpanName:                       "rootClientSpan",
+				elasticattr.EventOutcome:                   "success",
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.ServiceTargetName:              "T",
+				elasticattr.ServiceTargetType:              "rabbitmq",
+				elasticattr.TransactionID:                  "0100000000000000",
+				elasticattr.TransactionDurationUs:          int64(0),
+				elasticattr.TransactionRepresentativeCount: float64(1),
+				elasticattr.TransactionResult:              "Success",
+				elasticattr.TransactionType:                "messaging.rabbitmq",
+				elasticattr.TransactionSampled:             true,
+				elasticattr.TransactionRoot:                true,
+				elasticattr.SpanDurationUs:                 int64(0),
+				elasticattr.SpanRepresentativeCount:        float64(1),
 			},
 		},
 	} {

--- a/enrichments/trace/internal/elastic/span_test.go
+++ b/enrichments/trace/internal/elastic/span_test.go
@@ -430,6 +430,8 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 				AttributeTransactionType:                "external.http",
 				AttributeTransactionSampled:             true,
 				AttributeTransactionRoot:                true,
+				AttributeSpanDurationUs:                 int64(0),
+				AttributeSpanRepresentativeCount:        float64(1),
 			},
 		},
 		{
@@ -466,6 +468,8 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 				AttributeTransactionType:                "db.mssql",
 				AttributeTransactionSampled:             true,
 				AttributeTransactionRoot:                true,
+				AttributeSpanDurationUs:                 int64(0),
+				AttributeSpanRepresentativeCount:        float64(1),
 			},
 		},
 		{
@@ -504,6 +508,8 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 				AttributeTransactionType:                "messaging.rabbitmq",
 				AttributeTransactionSampled:             true,
 				AttributeTransactionRoot:                true,
+				AttributeSpanDurationUs:                 int64(0),
+				AttributeSpanRepresentativeCount:        float64(1),
 			},
 		},
 	} {

--- a/enrichments/trace/internal/elastic/span_test.go
+++ b/enrichments/trace/internal/elastic/span_test.go
@@ -388,6 +388,146 @@ func TestElasticTransactionEnrich(t *testing.T) {
 	}
 }
 
+// Tests root spans that represent a dependency and are mapped to a transaction.
+func TestRootSpanAsDependencyEnrich(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		input             ptrace.Span
+		config            config.Config
+		enrichedAttrs     map[string]any
+		expectedSpanLinks *ptrace.SpanLinkSlice
+	}{
+		{
+			name: "outgoing_http_root_span",
+			input: func() ptrace.Span {
+				span := ptrace.NewSpan()
+				span.SetName("rootClientSpan")
+				span.SetSpanID([8]byte{1})
+				span.SetKind(ptrace.SpanKindClient)
+				span.Attributes().PutStr(semconv.AttributeHTTPMethod, "GET")
+				span.Attributes().PutStr(semconv.AttributeHTTPURL, "http://localhost:8080")
+				span.Attributes().PutInt(semconv.AttributeHTTPResponseStatusCode, 200)
+				span.Attributes().PutStr(semconv.AttributeNetworkProtocolVersion, "1.1")
+				return span
+			}(),
+			config: config.Enabled(),
+			enrichedAttrs: map[string]any{
+				AttributeTimestampUs:                    int64(0),
+				AttributeTransactionName:                "rootClientSpan",
+				AttributeProcessorEvent:                 "transaction",
+				AttributeSpanType:                       "external",
+				AttributeSpanSubtype:                    "http",
+				AttributeSpanDestinationServiceResource: "localhost:8080",
+				AttributeSpanName:                       "rootClientSpan",
+				AttributeEventOutcome:                   "success",
+				AttributeSuccessCount:                   int64(1),
+				AttributeServiceTargetName:              "localhost:8080",
+				AttributeServiceTargetType:              "http",
+				AttributeTransactionID:                  "0100000000000000",
+				AttributeTransactionDurationUs:          int64(0),
+				AttributeTransactionRepresentativeCount: float64(1),
+				AttributeTransactionResult:              "HTTP 2xx",
+				AttributeTransactionType:                "external.http",
+				AttributeTransactionSampled:             true,
+				AttributeTransactionRoot:                true,
+			},
+		},
+		{
+			name: "db_root_span",
+			input: func() ptrace.Span {
+				span := ptrace.NewSpan()
+				span.SetName("rootClientSpan")
+				span.SetSpanID([8]byte{1})
+				span.SetKind(ptrace.SpanKindClient)
+				span.Attributes().PutStr(semconv.AttributeDBSystem, "mssql")
+
+				span.Attributes().PutStr(semconv.AttributeDBName, "myDb")
+				span.Attributes().PutStr(semconv.AttributeDBOperation, "SELECT")
+				span.Attributes().PutStr(semconv.AttributeDBStatement, "SELECT * FROM wuser_table")
+				return span
+			}(),
+			config: config.Enabled(),
+			enrichedAttrs: map[string]any{
+				AttributeTimestampUs:                    int64(0),
+				AttributeTransactionName:                "rootClientSpan",
+				AttributeProcessorEvent:                 "transaction",
+				AttributeSpanType:                       "db",
+				AttributeSpanSubtype:                    "mssql",
+				AttributeSpanDestinationServiceResource: "mssql",
+				AttributeSpanName:                       "rootClientSpan",
+				AttributeEventOutcome:                   "success",
+				AttributeSuccessCount:                   int64(1),
+				AttributeServiceTargetName:              "myDb",
+				AttributeServiceTargetType:              "mssql",
+				AttributeTransactionID:                  "0100000000000000",
+				AttributeTransactionDurationUs:          int64(0),
+				AttributeTransactionRepresentativeCount: float64(1),
+				AttributeTransactionResult:              "Success",
+				AttributeTransactionType:                "db.mssql",
+				AttributeTransactionSampled:             true,
+				AttributeTransactionRoot:                true,
+			},
+		},
+		{
+			name: "producer_messaging_span",
+			input: func() ptrace.Span {
+				span := ptrace.NewSpan()
+				span.SetName("rootClientSpan")
+				span.SetSpanID([8]byte{1})
+				span.SetKind(ptrace.SpanKindProducer)
+
+				span.Attributes().PutStr(semconv.AttributeServerAddress, "myServer")
+				span.Attributes().PutStr(semconv.AttributeServerPort, "1234")
+				span.Attributes().PutStr(semconv.AttributeMessagingSystem, "rabbitmq")
+				span.Attributes().PutStr(semconv.AttributeMessagingDestinationName, "T")
+				span.Attributes().PutStr(semconv.AttributeMessagingOperation, "publish")
+				span.Attributes().PutStr(semconv.AttributeMessagingClientID, "a")
+				return span
+			}(),
+			config: config.Enabled(),
+			enrichedAttrs: map[string]any{
+				AttributeTimestampUs:                    int64(0),
+				AttributeTransactionName:                "rootClientSpan",
+				AttributeProcessorEvent:                 "transaction",
+				AttributeSpanType:                       "messaging",
+				AttributeSpanSubtype:                    "rabbitmq",
+				AttributeSpanDestinationServiceResource: "rabbitmq/T",
+				AttributeSpanName:                       "rootClientSpan",
+				AttributeEventOutcome:                   "success",
+				AttributeSuccessCount:                   int64(1),
+				AttributeServiceTargetName:              "T",
+				AttributeServiceTargetType:              "rabbitmq",
+				AttributeTransactionID:                  "0100000000000000",
+				AttributeTransactionDurationUs:          int64(0),
+				AttributeTransactionRepresentativeCount: float64(1),
+				AttributeTransactionResult:              "Success",
+				AttributeTransactionType:                "messaging.rabbitmq",
+				AttributeTransactionSampled:             true,
+				AttributeTransactionRoot:                true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedSpan := ptrace.NewSpan()
+			tc.input.CopyTo(expectedSpan)
+
+			// Merge with the expected attributes and override the span links.
+			for k, v := range tc.enrichedAttrs {
+				expectedSpan.Attributes().PutEmpty(k).FromRaw(v)
+			}
+			// Override span links
+			if tc.expectedSpanLinks != nil {
+				tc.expectedSpanLinks.CopyTo(expectedSpan.Links())
+			} else {
+				expectedSpan.Links().RemoveIf(func(_ ptrace.SpanLink) bool { return true })
+			}
+
+			EnrichSpan(tc.input, tc.config)
+			assert.NoError(t, ptracetest.CompareSpan(expectedSpan, tc.input))
+		})
+	}
+}
+
 // Tests the enrichment logic for elastic's span definition.
 func TestElasticSpanEnrich(t *testing.T) {
 	now := time.Unix(3600, 0)

--- a/enrichments/trace/internal/elastic/span_test.go
+++ b/enrichments/trace/internal/elastic/span_test.go
@@ -412,14 +412,9 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:     int64(0),
-				AttributeTransactionName: "rootClientSpan",
-				AttributeProcessorEvent: func() pcommon.Slice {
-					p := pcommon.NewSlice()
-					p.AppendEmpty().SetStr("transaction")
-					p.AppendEmpty().SetStr("span")
-					return p
-				}().AsRaw(),
+				AttributeTimestampUs:                    int64(0),
+				AttributeTransactionName:                "rootClientSpan",
+				AttributeProcessorEvent:                 "transaction",
 				AttributeSpanType:                       "external",
 				AttributeSpanSubtype:                    "http",
 				AttributeSpanDestinationServiceResource: "localhost:8080",
@@ -455,14 +450,9 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:     int64(0),
-				AttributeTransactionName: "rootClientSpan",
-				AttributeProcessorEvent: func() pcommon.Slice {
-					p := pcommon.NewSlice()
-					p.AppendEmpty().SetStr("transaction")
-					p.AppendEmpty().SetStr("span")
-					return p
-				}().AsRaw(),
+				AttributeTimestampUs:                    int64(0),
+				AttributeTransactionName:                "rootClientSpan",
+				AttributeProcessorEvent:                 "transaction",
 				AttributeSpanType:                       "db",
 				AttributeSpanSubtype:                    "mssql",
 				AttributeSpanDestinationServiceResource: "mssql",
@@ -500,14 +490,9 @@ func TestRootSpanAsDependencyEnrich(t *testing.T) {
 			}(),
 			config: config.Enabled(),
 			enrichedAttrs: map[string]any{
-				AttributeTimestampUs:     int64(0),
-				AttributeTransactionName: "rootClientSpan",
-				AttributeProcessorEvent: func() pcommon.Slice {
-					p := pcommon.NewSlice()
-					p.AppendEmpty().SetStr("transaction")
-					p.AppendEmpty().SetStr("span")
-					return p
-				}().AsRaw(),
+				AttributeTimestampUs:                    int64(0),
+				AttributeTransactionName:                "rootClientSpan",
+				AttributeProcessorEvent:                 "transaction",
 				AttributeSpanType:                       "messaging",
 				AttributeSpanSubtype:                    "rabbitmq",
 				AttributeSpanDestinationServiceResource: "rabbitmq/T",


### PR DESCRIPTION
In the OTel data model it's allowed (and not very uncommon) to have a root span which in itself represents a dependency. Such spans are root and exit span at the same time.

Examples can be seen in the tests (e.g. outgoing HTTP call, just a span without root that represents a db call or produces a message). Such spans are mapped into a transaction, because in the Elastic data model we always need a transaction as root.

This PR adds logic to enrich such transactions with the necessary fields to calculate dependencies and draw a service map.

Follow up PR in Kibana will still need to be done to query such transactions - currently only `processor.event: span` is used for dependencies. This PR adds all the necessary fields, so then those queries can be updated and filtering on `processor.event` can be removed (or explicitly filter to both spans and transaction in case removing is not needed). 