### PR TITLE
Add rpc.service for the destination.service.resource calculation

### DIFF
--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -463,6 +463,9 @@ func (s *spanEnrichmentContext) setDestinationService(span ptrace.Span) {
 				s.serverAddress, s.serverPort, // fallback
 			); res != "" {
 				destnResource = res
+			} else {
+				// fallback to RPC service
+				destnResource = s.rpcService
 			}
 		}
 	}


### PR DESCRIPTION
@AlexanderWert pointed out that some services in the OTel demo send GRPC spans with very few SemConv attributes. Here is an example of such a span from the `recommendation` python service:

```
{
    "attributes": {  
      "rpc.grpc.status_code": 0,
      "rpc.method": "ListProducts",
      "rpc.service": "oteldemo.ProductCatalogService",
      "rpc.system": "grpc",
    },
```

Although [according to SemConv RPC spans have required attribute `server.address`](https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/) - it's not set by this python service. None of the other fields we use for `destination.service.resource` are set, but we have `rpc.service`. 

The problem with this is that without `destination.service.resource`, the service map won't show this dependency.

@AlexanderWert suggested to then just use this field as a fallback and set that as `destination.service.resource`, which I think makes sense, because this field is needed for service map and `rpc.service` still identifies the target service.

Service map prior to this PR:
<img width="2302" alt="Screenshot 2025-02-28 at 18 05 57" src="https://github.com/user-attachments/assets/2eba585f-8fc2-4174-adef-4e11473ecbd9" />


Service map with this PR:
<img width="1585" alt="Screenshot 2025-02-28 at 18 39 34" src="https://github.com/user-attachments/assets/f6ae49d5-2e5f-49f5-976d-3db1cd2707e2" />


Not the real service is still not resolved on the map, but I'm not sure it's related to this thing... I see that all the time, also when the call happens via HTTP. So far my guess is that it's not relevant, but if someone knows more, let me know. 
