### PR TITLE
Normalize service.name as apm-data does

### DIFF
--- a/enrichments/trace/config/config.go
+++ b/enrichments/trace/config/config.go
@@ -31,6 +31,7 @@ type ResourceConfig struct {
 	AgentName        AttributeConfig `mapstructure:"agent_name"`
 	AgentVersion     AttributeConfig `mapstructure:"agent_version"`
 	OverrideHostName AttributeConfig `mapstructure:"override_host_name"`
+	ServiceName      AttributeConfig `mapstructure:"service_name"`
 }
 
 // ScopeConfig configures the enrichment of scope attributes.
@@ -106,6 +107,7 @@ func Enabled() Config {
 			AgentName:        AttributeConfig{Enabled: true},
 			AgentVersion:     AttributeConfig{Enabled: true},
 			OverrideHostName: AttributeConfig{Enabled: true},
+			ServiceName:      AttributeConfig{Enabled: true},
 		},
 		Scope: ScopeConfig{
 			ServiceFrameworkName:    AttributeConfig{Enabled: true},

--- a/enrichments/trace/internal/elastic/resource_test.go
+++ b/enrichments/trace/internal/elastic/resource_test.go
@@ -194,6 +194,20 @@ func TestResourceEnrich(t *testing.T) {
 				elasticattr.AgentVersion:     "unknown",
 			},
 		},
+		{
+			name: "normalize_service_name",
+			input: func() pcommon.Resource {
+				res := pcommon.NewResource()
+				res.Attributes().PutStr(semconv.AttributeServiceName, "Apache/Drupal")
+				return res
+			}(),
+			config: config.Enabled().Resource,
+			enrichedAttrs: map[string]any{
+				semconv.AttributeServiceName: "Apache_Drupal",
+				elasticattr.AgentName:        "otlp",
+				elasticattr.AgentVersion:     "unknown",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Merge existing resource attrs with the attrs added


### PR DESCRIPTION
Solves https://github.com/elastic/opentelemetry-lib/issues/169.

Before merge, we need to decide if we go with this solution or we prefer https://github.com/elastic/kibana/issues/213943 and don't need this. I'll wait with merging until we have clear agreement.

This PR normalizes `service.name` the same way [as `apm-data` does](https://github.com/elastic/apm-data/blob/main/input/otlp/metadata.go#L489). 

This is especially relevant for values where `service.name` would expect values that Kibana can't handle currently - such example is `/` which seems to be used by the PHP OTel SDK.