### PR TITLE
Handle deployment.environment.name

### DIFF
--- a/enrichments/trace/config/config.go
+++ b/enrichments/trace/config/config.go
@@ -28,9 +28,10 @@ type Config struct {
 
 // ResourceConfig configures the enrichment of resource attributes.
 type ResourceConfig struct {
-	AgentName        AttributeConfig `mapstructure:"agent_name"`
-	AgentVersion     AttributeConfig `mapstructure:"agent_version"`
-	OverrideHostName AttributeConfig `mapstructure:"override_host_name"`
+	AgentName             AttributeConfig `mapstructure:"agent_name"`
+	AgentVersion          AttributeConfig `mapstructure:"agent_version"`
+	OverrideHostName      AttributeConfig `mapstructure:"override_host_name"`
+	DeploymentEnvironment AttributeConfig `mapstructure:"deployment_environment"`
 }
 
 // ScopeConfig configures the enrichment of scope attributes.
@@ -105,9 +106,10 @@ type AttributeConfig struct {
 func Enabled() Config {
 	return Config{
 		Resource: ResourceConfig{
-			AgentName:        AttributeConfig{Enabled: true},
-			AgentVersion:     AttributeConfig{Enabled: true},
-			OverrideHostName: AttributeConfig{Enabled: true},
+			AgentName:             AttributeConfig{Enabled: true},
+			AgentVersion:          AttributeConfig{Enabled: true},
+			OverrideHostName:      AttributeConfig{Enabled: true},
+			DeploymentEnvironment: AttributeConfig{Enabled: true},
 		},
 		Scope: ScopeConfig{
 			ServiceFrameworkName:    AttributeConfig{Enabled: true},

--- a/enrichments/trace/internal/elastic/resource.go
+++ b/enrichments/trace/internal/elastic/resource.go
@@ -81,7 +81,6 @@ func (s *resourceEnrichmentContext) Enrich(resource pcommon.Resource, cfg config
 	if cfg.OverrideHostName.Enabled {
 		s.overrideHostNameWithK8sNodeName(resource)
 	}
-
 	if cfg.DeploymentEnvironment.Enabled {
 		s.setDeploymentEnvironment(resource)
 	}

--- a/enrichments/trace/internal/elastic/resource.go
+++ b/enrichments/trace/internal/elastic/resource.go
@@ -91,10 +91,8 @@ func (s *resourceEnrichmentContext) Enrich(resource pcommon.Resource, cfg config
 // ES currently doesn't allow aliases with multiple targets, so if the new field name is used (SemConv v1.27+),
 // we duplicate the value and also send it with the old field name to make the alias work.
 func (s *resourceEnrichmentContext) setDeploymentEnvironment(resource pcommon.Resource) {
-	if s.deploymentEnvironmentName != "" {
-		if s.deploymentEnvironment == "" {
-			resource.Attributes().PutStr(semconv25.AttributeDeploymentEnvironment, s.deploymentEnvironmentName)
-		}
+	if s.deploymentEnvironmentName != "" && s.deploymentEnvironment == "" {
+		resource.Attributes().PutStr(semconv25.AttributeDeploymentEnvironment, s.deploymentEnvironmentName)
 	}
 }
 

--- a/enrichments/trace/internal/elastic/resource.go
+++ b/enrichments/trace/internal/elastic/resource.go
@@ -42,6 +42,9 @@ type resourceEnrichmentContext struct {
 	telemetrySDKVersion    string
 	telemetryDistroName    string
 	telemetryDistroVersion string
+
+	deploymentEnvironment     string
+	deploymentEnvironmentName string
 }
 
 func (s *resourceEnrichmentContext) Enrich(resource pcommon.Resource, cfg config.ResourceConfig) {
@@ -61,6 +64,10 @@ func (s *resourceEnrichmentContext) Enrich(resource pcommon.Resource, cfg config
 			s.telemetryDistroName = v.Str()
 		case semconv.AttributeTelemetryDistroVersion:
 			s.telemetryDistroVersion = v.Str()
+		case semconv25.AttributeDeploymentEnvironment:
+			s.deploymentEnvironment = v.Str()
+		case semconv.AttributeDeploymentEnvironmentName:
+			s.deploymentEnvironmentName = v.Str()
 		}
 		return true
 	})
@@ -85,9 +92,9 @@ func (s *resourceEnrichmentContext) Enrich(resource pcommon.Resource, cfg config
 // ES currently doesn't allow aliases with multiple targets, so if the new field name is used (SemConv v1.27+),
 // we duplicate the value and also send it with the old field name to make the alias work.
 func (s *resourceEnrichmentContext) setDeploymentEnvironment(resource pcommon.Resource) {
-	if deploymentEnvironmentName, deploymentEnvironmentNameExists := resource.Attributes().Get(semconv.AttributeDeploymentEnvironmentName); deploymentEnvironmentNameExists {
-		if _, deploymentEnvironmentExists := resource.Attributes().Get(semconv25.AttributeDeploymentEnvironment); !deploymentEnvironmentExists {
-			resource.Attributes().PutStr(semconv25.AttributeDeploymentEnvironment, deploymentEnvironmentName.AsString())
+	if s.deploymentEnvironmentName != "" {
+		if s.deploymentEnvironment == "" {
+			resource.Attributes().PutStr(semconv25.AttributeDeploymentEnvironment, s.deploymentEnvironmentName)
 		}
 	}
 }


### PR DESCRIPTION
`deployment.environment.name`  was introduced in SemConv  [v1.27.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0) and `deployment.environment` got deprecated.

In the `otel-data` ES plugin we alias `service.environment` to `deployment.environment`.  `service.environment` is used by Kibana to show the environment.

In this PR, if `deployment.environment.name` is set, we duplicate it into `deployment.environment` in order to make the `service.environment` -> `deployment.environment` work.

So far there is no better solution on the table - ideally we'd need an ES feature where the `service.environment` alias has two targets, but currently that is not possible in ES.