### PR TITLE
Fix handling of non root span that represent a dependency

### DIFF
--- a/enrichments/trace/internal/elastic/span.go
+++ b/enrichments/trace/internal/elastic/span.go
@@ -220,7 +220,7 @@ func (s *spanEnrichmentContext) enrich(span ptrace.Span, cfg config.Config) {
 	// In OTel, a local root span can represent an outgoing call or a producer span.
 	// In such cases, the span is still mapped into a transaction, but enriched
 	// with additional attributes that are specific to the outgoing call or producer span.
-	isExitRootSpan := s.isTransaction && span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer
+	isExitRootSpan := s.isTransaction && (span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer)
 
 	if s.isTransaction {
 		s.enrichTransaction(span, cfg.Transaction)


### PR DESCRIPTION
Regression reported by @AlexanderWert.

Problem was missing `(` `)` when dependencies were calculated resulting in mapping a non-root span partly as a transaction and not setting `processor.event`.

Also added a test covering such cases. 