### PR TITLE
Set agent name and version conditionally

### DIFF
--- a/enrichments/internal/elastic/resource.go
+++ b/enrichments/internal/elastic/resource.go
@@ -75,13 +75,11 @@ func (s *resourceEnrichmentContext) Enrich(resource pcommon.Resource, cfg config
 	// agent.name and version are set by classic Elastic APM Agents - if the value is present, we take it
 	// otherwise the setAgent[Name|Version] functions are called to derive the values
 	if cfg.AgentName.Enabled {
-		s.setAgentName(resource)
 		if _, exists := resource.Attributes().Get(elasticattr.AgentName); !exists {
 			s.setAgentName(resource)
 		}
 	}
 	if cfg.AgentVersion.Enabled {
-		s.setAgentVersion(resource)
 		if _, exists := resource.Attributes().Get(elasticattr.AgentVersion); !exists {
 			s.setAgentVersion(resource)
 		}


### PR DESCRIPTION
`agent.name` is a required field in Kibana - without that the APM UI throws an exception.

Via the `elasticapmintake` receiver these fields are set and we get the values out of the box (elastic APM Agents send those values) - and the processor just disabled these 2 fields: https://github.com/gregkalapos/opentelemetry-collector-components/blob/main/processor/elasticapmprocessor/processor.go#L69-L70

For OTel SDKs via the OTLP receiver, we just called the `s.setAgentName` and `s.setAgentVersion` functions to calculate those - because the lines below for disabling the fields are only active for ecs mode.

This breaks when OTel SDKs are used in `ecs` mode ("internal linked" to internal issue below for more details).

The idea:
- in the `opentelemetry-lib` here we calculate these 2 fields when they are not present - otherwise just take them as-is.
- I'll open another issue to remove the `p.enricher.Config.Resource.Agent[Name|version].Enabled = false` lines for ecs mode - update: PR in the other repo: https://github.com/elastic/opentelemetry-collector-components/pull/758 

This way, we handle it like this:
- Elastic APM Agents via `elasticapmintake` receiver: values are present, just take them as is
- OTLP receiver with otel mode: value not present, we calculate it
- OTLP receiver with ecs mode: same as above
